### PR TITLE
Added build flags to OpenDPN3 build on custom

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -514,7 +514,7 @@ elif [ "$1" == "custom" ]; then
     sudo dd if=/dev/zero of=swapfile bs=1M count=1000
     sudo mkswap swapfile
     sudo swapon swapfile
-    cmake ../dnp3_src
+    cmake ../dnp3_src -DFULL=ON -DCMAKE_INSTALL_PREFIX=/usr
     make
     sudo make install
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
This build flag fixes building OpenPLC building on "unsupported" linux systems. 
Starting the OpenPLC runtime results in: 
./core/openplc: error while loading shared libraries: libasiodnp3.so: cannot open shared object file: No such file or directory

I've seen someone else also struggling with this problem as well in this forum topic:
https://openplc.discussion.community/post/running-openplc-runtime-in-arch-linux-9783271

With this commit this problem should be fixed without having to manually link to the libraries.