### PR TITLE
Added build flag for libmodbus_src on custom

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -532,7 +532,7 @@ elif [ "$1" == "custom" ]; then
     echo "[LIBMODBUS]"
     cd utils/libmodbus_src
     ./autogen.sh
-    ./configure
+    ./configure --prefix=/usr
     sudo make install
     if [ $? -ne 0 ]; then
         echo "Error installing Libmodbus"


### PR DESCRIPTION
During building libmodbus on (in my case Fedora 29) build process of OpenPLC fails due to some files like for instance libmodbus.so which cannot be found while the libraries are present in /usr/local/lib. Setting the build flag "--prefix=/usr" fixes OpenPLC build process for Fedora 29 and probably also other Linux distro's else than Debian