### PR TITLE
Add Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: python
+language: bash
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+services:
+  - docker
+  
+script:
+  - docker build -t OpenPLC:v3 .
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+language: python
+
 services:
   - docker
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ services:
   - docker
   
 script:
-  - docker build -t OpenPLC:v3 .
+  - docker build .
   


### PR DESCRIPTION
This PR creates a `.travis.yml` file that just does a build of the container image using the `Dockerfile`.

@thiagoralves you will have to enable Travis CI for this repo additionally to get the builds.