### PR TITLE
Make checking out the code from Windows work by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Shell script files should never have line endings converted
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ public/
 
 *.pyc
 
-
+# IDE files for Visual Studio Code
+*.vscode/


### PR DESCRIPTION
Previously if you checkout the code on Windows, the line endings for shell scripts could be converted to CRLF line endings. That breaks the scripts in all terminals. This change says "for *.sh, always use LF" line endings.