### PR TITLE
Port OpenPLC to Python 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian
 
 RUN apt-get update \
 && apt-get install -y build-essential pkg-config bison flex autoconf \
-automake libtool make git python2.7 python-pip  \
+automake libtool make git python3 python3-pip  \
 sqlite3 cmake git
 
 COPY . /workdir

--- a/background_installer.sh
+++ b/background_installer.sh
@@ -31,15 +31,12 @@ cp webserver/openplc.db ./etc/
 function linux_install_deps {
     $1 apt-get update
     $1 apt-get install -y build-essential pkg-config bison flex autoconf \
-                          automake libtool make git python2.7 python-pip  \
+                          automake libtool make git python3 python3-pip   \
                           sqlite3 cmake git
 }
 
 function install_py_deps {
-    $1 pip install flask
-    $1 pip install flask-login
-    $1 pip install pyserial
-    $1 pip install pymodbus
+    $1 pip3 install -r requirements.txt
 }
 
 function OPLC_background_service {
@@ -87,14 +84,11 @@ if [ "$1" == "win" ]; then
     apt-cyg update
     apt-cyg install lynx
     rm -f /bin/wget.exe
-    apt-cyg remove gcc-core gcc-g++ pkg-config automake autoconf libtool make python2 python2-pip sqlite3
-    apt-cyg install wget gcc-core gcc-g++ git pkg-config automake autoconf libtool make python2 python2-pip sqlite3
+    apt-cyg remove gcc-core gcc-g++ pkg-config automake autoconf libtool make python3 python3-pip sqlite3
+    apt-cyg install wget gcc-core gcc-g++ git pkg-config automake autoconf libtool make python3 python3-pip sqlite3
     lynx -source https://bootstrap.pypa.io/get-pip.py > get-pip.py
-    python get-pip.py
-    pip install flask
-    pip install flask-login
-    pip install pyserial
-    pip install pymodbus
+    python3 get-pip.py
+    pip install -r requirements.txt
 
     rm apt-cyg
     rm get-pip.py

--- a/start_openplc.sh
+++ b/start_openplc.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 cd webserver
-python2 webserver.py
+python3 webserver.py

--- a/webserver/monitoring.py
+++ b/webserver/monitoring.py
@@ -39,9 +39,9 @@ def parse_st(st_file):
                 debug_vars.append(debug_data)
     
     for debugs in debug_vars:
-        print('Name: ' + debugs.name)
-        print('Location: ' + debugs.location)
-        print('Type: ' + debugs.type)
+        print(('Name: ' + debugs.name))
+        print(('Location: ' + debugs.location))
+        print(('Type: ' + debugs.type))
         print('')
 
 

--- a/webserver/openplc.py
+++ b/webserver/openplc.py
@@ -23,7 +23,7 @@ import errno
 import time
 import os
 from threading import Thread
-from Queue import Queue, Empty
+from queue import Queue, Empty
 
 self_path = os.path.dirname(__file__)
 
@@ -115,7 +115,7 @@ class runtime:
                     time.sleep(1)  # https://www.reddit.com/r/learnpython/comments/776r96/defunct_python_process_when_using_subprocesspopen/
 
             except socket.error as serr:
-                print("Failed to stop the runtime. Error: " + str(serr))
+                print(("Failed to stop the runtime. Error: " + str(serr)))
     
     def compile_program(self, st_file):
         if (self.status() == "Running"):
@@ -156,7 +156,7 @@ class runtime:
                 s.close()
                 self.runtime_status = "Running"
             except socket.error as serr:
-                print("OpenPLC Runtime is not running. Error: " + str(serr))
+                print(("OpenPLC Runtime is not running. Error: " + str(serr)))
                 self.runtime_status = "Stopped"
         
         return self.runtime_status

--- a/webserver/webserver.py
+++ b/webserver/webserver.py
@@ -63,35 +63,35 @@ def configure_runtime():
             for row in rows:
                 if (row[0] == "Modbus_port"):
                     if (row[1] != "disabled"):
-                        print("Enabling Modbus on port " + str(int(row[1])))
+                        print(("Enabling Modbus on port " + str(int(row[1]))))
                         openplc_runtime.start_modbus(int(row[1]))
                     else:
                         print("Disabling Modbus")
                         openplc_runtime.stop_modbus()
                 elif (row[0] == "Dnp3_port"):
                     if (row[1] != "disabled"):
-                        print("Enabling DNP3 on port " + str(int(row[1])))
+                        print(("Enabling DNP3 on port " + str(int(row[1]))))
                         openplc_runtime.start_dnp3(int(row[1]))
                     else:
                         print("Disabling DNP3")
                         openplc_runtime.stop_dnp3()
                 elif (row[0] == "Enip_port"):
                     if (row[1] != "disabled"):
-                        print("Enabling EtherNet/IP on port " + str(int(row[1])))
+                        print(("Enabling EtherNet/IP on port " + str(int(row[1]))))
                         openplc_runtime.start_enip(int(row[1]))
                     else:
                         print("Disabling EtherNet/IP")
                         openplc_runtime.stop_enip()
                 elif (row[0] == "Pstorage_polling"):
                     if (row[1] != "disabled"):
-                        print("Enabling Persistent Storage with polling rate of " + str(int(row[1])) + " seconds")
+                        print(("Enabling Persistent Storage with polling rate of " + str(int(row[1])) + " seconds"))
                         openplc_runtime.start_pstorage(int(row[1]))
                     else:
                         print("Disabling Persistent Storage")
                         openplc_runtime.stop_pstorage()
                         delete_persistent_file()
         except Error as e:
-            print("error connecting to the database" + str(e))
+            print(("error connecting to the database" + str(e)))
     else:
         print("Error opening DB")
 
@@ -176,7 +176,7 @@ def generate_mbconfig():
             with open('./mbconfig.cfg', 'w+') as f: f.write(mbconfig)
             
         except Error as e:
-            print("error connecting to the database" + str(e))
+            print(("error connecting to the database" + str(e)))
     else:
         print("Error opening DB")
                 
@@ -390,7 +390,7 @@ def user_loader(username):
             return
                     
         except Error as e:
-            print("error connecting to the database" + str(e))
+            print(("error connecting to the database" + str(e)))
             return
     else:
         return
@@ -421,7 +421,7 @@ def request_loader(request):
             return
                     
         except Error as e:
-            print("error connecting to the database" + str(e))
+            print(("error connecting to the database" + str(e)))
             return
     else:
         return
@@ -474,7 +474,7 @@ def login():
             return pages.login_head + pages.bad_login_body
                     
         except Error as e:
-            print("error connecting to the database" + str(e))
+            print(("error connecting to the database" + str(e)))
             return 'Error opening DB'
     else:
         return 'Error opening DB'
@@ -640,7 +640,7 @@ def programs():
     </body>
 </html>"""
             except Error as e:
-                print("error connecting to the database" + str(e))
+                print(("error connecting to the database" + str(e)))
                 return_str += 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.<br><br>Error: ' + str(e)
         else:
             return_str += 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.'
@@ -701,7 +701,7 @@ def reload_program():
 </html>"""
 
             except Error as e:
-                print("error connecting to the database" + str(e))
+                print(("error connecting to the database" + str(e)))
                 return_str += 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.<br><br>Error: ' + str(e)
         else:
             return_str += 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.'
@@ -728,7 +728,7 @@ def remove_program():
                 return flask.redirect(flask.url_for('programs'))
                 
             except Error as e:
-                print("error connecting to the database" + str(e))
+                print(("error connecting to the database" + str(e)))
                 return 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.<br><br>Error: ' + str(e)
         else:
             return 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.'
@@ -838,7 +838,7 @@ def upload_program_action():
                 return '<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=/compile-program?file=' + prog_file + '"></head></html>'
             
             except Error as e:
-                print("error connecting to the database" + str(e))
+                print(("error connecting to the database" + str(e)))
                 return 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.<br><br>Error: ' + str(e)
         else:
             return 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.'
@@ -867,7 +867,7 @@ def compile_program():
                 cur.close()
                 conn.close()
             except Error as e:
-                print("error connecting to the database" + str(e))
+                print(("error connecting to the database" + str(e)))
         else:
             print("error connecting to the database")
         
@@ -985,7 +985,7 @@ def modbus():
 </html>"""
 
             except Error as e:
-                print("error connecting to the database" + str(e))
+                print(("error connecting to the database" + str(e)))
                 return_str += 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.<br><br>Error: ' + str(e)
         else:
             return_str += 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.'
@@ -1102,7 +1102,7 @@ def add_modbus_device():
                     return flask.redirect(flask.url_for('modbus'))
                     
                 except Error as e:
-                    print("error connecting to the database" + str(e))
+                    print(("error connecting to the database" + str(e)))
                     return 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.<br><br>Error: ' + str(e)
             else:
                 return 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.'
@@ -1227,7 +1227,7 @@ def modbus_edit_device():
                     return_str += 'aowsize.value = "' + str(row[20]) + '";}</script></html>'
                     
                 except Error as e:
-                    print("error connecting to the database" + str(e))
+                    print(("error connecting to the database" + str(e)))
                     return_str += 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.<br><br>Error: ' + str(e)
             else:
                 return_str += 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.'
@@ -1272,7 +1272,7 @@ def modbus_edit_device():
                     return flask.redirect(flask.url_for('modbus'))
                     
                 except Error as e:
-                    print("error connecting to the database" + str(e))
+                    print(("error connecting to the database" + str(e)))
                     return 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.<br><br>Error: ' + str(e)
             else:
                 return 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.'
@@ -1297,7 +1297,7 @@ def delete_device():
                 generate_mbconfig()
                 return flask.redirect(flask.url_for('modbus'))
             except Error as e:
-                print("error connecting to the database" + str(e))
+                print(("error connecting to the database" + str(e)))
                 return 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.<br><br>Error: ' + str(e)
         else:
             return 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.'
@@ -1690,7 +1690,7 @@ def users():
     </body>
 </html>"""
             except Error as e:
-                print("error connecting to the database" + str(e))
+                print(("error connecting to the database" + str(e)))
                 return_str += 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.<br><br>Error: ' + str(e)
         else:
             return_str += 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.'
@@ -1755,7 +1755,7 @@ def add_user():
                     return flask.redirect(flask.url_for('users'))
                     
                 except Error as e:
-                    print("error connecting to the database" + str(e))
+                    print(("error connecting to the database" + str(e)))
                     return 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.<br><br>Error: ' + str(e)
             else:
                 return 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.'
@@ -1844,7 +1844,7 @@ def edit_user():
     </script>
 </html>"""
                 except Error as e:
-                    print("error connecting to the database" + str(e))
+                    print(("error connecting to the database" + str(e)))
                     return_str += 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.<br><br>Error: ' + str(e)
             else:
                 return_str += 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.'
@@ -1884,7 +1884,7 @@ def edit_user():
                     return flask.redirect(flask.url_for('users'))
                     
                 except Error as e:
-                    print("error connecting to the database" + str(e))
+                    print(("error connecting to the database" + str(e)))
                     return 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.<br><br>Error: ' + str(e)
             else:
                 return 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.'
@@ -1916,7 +1916,7 @@ def delete_user():
                     conn.close()
                     return flask.redirect(flask.url_for('users'))
             except Error as e:
-                print("error connecting to the database" + str(e))
+                print(("error connecting to the database" + str(e)))
                 return 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.<br><br>Error: ' + str(e)
         else:
             return 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.'
@@ -2158,7 +2158,7 @@ def settings():
                     return flask.redirect(flask.url_for('dashboard'))
                     
                 except Error as e:
-                    print("error connecting to the database" + str(e))
+                    print(("error connecting to the database" + str(e)))
                     return 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.<br><br>Error: ' + str(e)
             else:
                 return 'Error connecting to the database. Make sure that your ../etc/openplc.db file is not corrupt.'
@@ -2205,9 +2205,6 @@ if __name__ == '__main__':
     st_file = file.read()
     st_file = st_file.replace('\r','').replace('\n','')
     
-    reload(sys)
-    sys.setdefaultencoding('UTF8')
-    
     database = "../etc/openplc.db"
     conn = create_connection(database)
     if (conn != None):
@@ -2238,6 +2235,6 @@ if __name__ == '__main__':
             app.run(debug=False, host='0.0.0.0', threaded=True, port=8080)
         
         except Error as e:
-            print("error connecting to the database" + str(e))
+            print(("error connecting to the database" + str(e)))
     else:
         print("error connecting to the database")


### PR DESCRIPTION
Pretty straight forward port to Python 3.
I'm not 100% sure about the Windows specific part in `background_installer.sh` as I don't have a Windows license around to test.

I use `pip3 install -r requirements.txt` in `background_installer.sh` now as that makes it easier to maintain the Python dependencies (only one place to change things).