### PR TITLE
Unify relative includes paths

### DIFF
--- a/runtime/core/dnp3s/dnp3.cpp
+++ b/runtime/core/dnp3s/dnp3.cpp
@@ -55,8 +55,8 @@
 #include "dnp3.h"
 #include "dnp3_publisher.h"
 #include "dnp3_receiver.h"
-#include "../ini_util.h"
-#include "../service/service_definition.h"
+#include "ini_util.h"
+#include "service/service_definition.h"
 
 
 /** \addtogroup openplc_runtime

--- a/runtime/core/modbusmaster/master.cpp
+++ b/runtime/core/modbusmaster/master.cpp
@@ -31,8 +31,8 @@
 #include "ladder.h"
 #include "master.h"
 #include "master_indexed.h"
-#include "../glue.h"
-#include "../ini_util.h"
+#include "glue.h"
+#include "ini_util.h"
 
 using namespace std;
 

--- a/runtime/core/modbusslave/indexed_strategy.cpp
+++ b/runtime/core/modbusslave/indexed_strategy.cpp
@@ -19,7 +19,7 @@
 
 #include "indexed_strategy.h"
 #include "mb_util.h"
-#include "../glue.h"
+#include "glue.h"
 
 /** \addtogroup openplc_runtime
  *  @{

--- a/runtime/core/modbusslave/indexed_strategy.h
+++ b/runtime/core/modbusslave/indexed_strategy.h
@@ -19,7 +19,7 @@
 #include <mutex>
 #include <vector>
 #include "buffer.h"
-#include "lib/iec_types_all.h"
+#include "iec_types_all.h"
 
 /** \addtogroup openplc_runtime
  *  @{

--- a/runtime/core/modbusslave/slave.cpp
+++ b/runtime/core/modbusslave/slave.cpp
@@ -31,9 +31,9 @@
 #include "slave.h"
 #include "indexed_strategy.h"
 #include "mb_util.h"
-#include "../ladder.h"
-#include "../glue.h"
-#include "../ini_util.h"
+#include "ladder.h"
+#include "glue.h"
+#include "ini_util.h"
 
 /** \addtogroup openplc_runtime
  *  @{

--- a/runtime/core/pstorage.cpp
+++ b/runtime/core/pstorage.cpp
@@ -36,7 +36,7 @@
 #include "ini_util.h"
 #include "ladder.h"
 #include "pstorage.h"
-#include "lib/iec_types_all.h"
+#include "iec_types_all.h"
 
 /** \addtogroup openplc_runtime
  *  @{

--- a/runtime/core/service/service_definition.cpp
+++ b/runtime/core/service/service_definition.cpp
@@ -16,8 +16,8 @@
 #include <algorithm>
 
 #include "service_definition.h"
-#include "../glue.h"
-#include "../ladder.h"
+#include "glue.h"
+#include "ladder.h"
 
 using namespace std;
 

--- a/runtime/core/service/service_registry.cpp
+++ b/runtime/core/service/service_registry.cpp
@@ -19,9 +19,9 @@
 #include "service_registry.h"
 #include "interactive_server.h"
 #include "pstorage.h"
-#include "../modbusslave/slave.h"
-#include "../modbusmaster/master_indexed.h"
-#include "../dnp3s/dnp3.h"
+#include "modbusslave/slave.h"
+#include "modbusmaster/master_indexed.h"
+#include "dnp3s/dnp3.h"
 
 using namespace std;
 using namespace oplc::modbusm;


### PR DESCRIPTION
As runtime/core and runtime/core/lib are already added to the include path by CMake we don't have
to reference them with '../' or 'lib/'.

@garretfick: Could you please have a look if I missed something here?