### PR TITLE
Fix the build of glue_generator

### DIFF
--- a/utils/glue_generator_src/CMakeLists.txt
+++ b/utils/glue_generator_src/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 cmake_minimum_required(VERSION 3.0.0)
 
-project(glue_generator LANGUAGES CXX VERSION 0.0.1)
+project(glue_generator VERSION 0.0.1)
 
 # CMake build for OpenPLC glue generator. The glue generator takes
 # generated C code from the MATIEC compiler and then generates necessary


### PR DESCRIPTION
Without this fix I get a linker error, as 'md5.c' is treated as a C++ file. Compiling it with a C compiler is fine as md5.h defines 'extern "C"' anyway.

@garretfick: Does this work for you?