### PR TITLE
ISSUE-112 Fail the glue generator if the second index is out of range

### DIFF
--- a/utils/glue_generator_src/CMakeLists.txt
+++ b/utils/glue_generator_src/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 cmake_minimum_required(VERSION 3.0.0)
 
-project(glue_generator LANGUAGES CXX VERSION 0.0.1)
+project(glue_generator VERSION 0.0.1)
 
 # CMake build for OpenPLC glue generator. The glue generator takes
 # generated C code from the MATIEC compiler and then generates necessary

--- a/utils/glue_generator_src/glue_generator.cpp
+++ b/utils/glue_generator_src/glue_generator.cpp
@@ -506,7 +506,8 @@ uint8_t generateBody(istream& locatedVars, ostream& glueVars, md5_byte_t digest[
         findPositions(iecVar_name, &pos1, &pos2);
 
         if (pos2 > 7) {
-            cout << "Sub-position of variable " << iecVar_name << " must be in the range 0 to 7";
+            cout << "Sub-position of variable " << iecVar_name
+                << " must be in the range 0 to 7" << endl;
             return -1;
         }
 
@@ -596,7 +597,7 @@ int mainImpl(int argc, char const * const *argv) {
     generateHeader(output_stream);
 
     md5_byte_t digest[16];
-    if (!generateBody(locatedVars, output_stream, digest)) {
+    if (generateBody(locatedVars, output_stream, digest) != 0) {
         return 1;
     }
     generateChecksum(output_stream, digest);

--- a/utils/glue_generator_src/test/glue_generator_test.cpp
+++ b/utils/glue_generator_src/test/glue_generator_test.cpp
@@ -66,8 +66,14 @@ SCENARIO("", "") {
         std::stringstream output_stream;
         md5_byte_t digest[16];
 
+        WHEN("Contains single BOOL at %IX0.8 is invalid index") {
+            std::stringstream input_stream("__LOCATED_VAR(BOOL,__IX0,I,X,0, 8)");
+            auto result = generateBody(input_stream, output_stream, digest);
+            REQUIRE(result != 0);
+        }
+
         WHEN("Contains single BOOL at %IX0") {
-            std::stringstream input_stream("__LOCATED_VAR(BOOL,__IX0,I,X,0)");
+            std::stringstream input_stream("__LOCATED_VAR(BOOL,__IX0_8,I,X,0)");
             generateBody(input_stream, output_stream, digest);
             const char* expected = PREFIX "\tbool_input[0][0] = __IX0;\n" POSTFIX
                 "GlueBoolGroup ___IG0 { .index=0, .values={ __IX0, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, } };\n"


### PR DESCRIPTION
This ensures that if the index is out of the permitted design range, then the glue generator returns an error.