### PR TITLE
Fix compilation issue.

### DIFF
--- a/runtime/core/bootstrap.cpp
+++ b/runtime/core/bootstrap.cpp
@@ -98,7 +98,7 @@ void setThreadPriorityRT()
     struct sched_param sp;
     sp.sched_priority = 30;
     spdlog::info("Setting main thread priority to RT");
-    if (pthread_setschedparam(std::this_thread::native_handle(), SCHED_FIFO, &sp))
+    if (pthread_setschedparam(pthread_self(), SCHED_FIFO, &sp))
     {
         spdlog::warn("Failed to set main thread to real-time priority");
     }


### PR DESCRIPTION
#142 introduced a compilation error on Linux:

```
/OpenPLC_v3/runtime/core/bootstrap.cpp: In function 'void setThreadPriorityRT()':
/OpenPLC_v3/runtime/core/bootstrap.cpp:101:49: error: 'native_handle' is not a member of 'std::this_thread'
  101 |     if (pthread_setschedparam(std::this_thread::native_handle(), SCHED_FIFO, &sp))
      |                                                 ^~~~~~~~~~~~~
make[2]: *** [CMakeFiles/openplc.dir/build.make:63: CMakeFiles/openplc.dir/runtime/core/bootstrap.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:437: CMakeFiles/openplc.dir/all] Error 2
make: *** [Makefile:130: all] Error 2
```

The issue is that no C++ standard yet released defines `std::this_thread::native_handle()`. There was a [proposal](https://cplusplus.github.io/LWG/issue2379) for such a function, but it does not appear to be accepted at this time. Note, `std::thread::native_handle()` exists, but there does not appear to be a mechanism in C++ to get a `std::thread` object referring to the current thread. Confusingly, `std::this_thread` is not a `std::thread` but just a namespace with a few functions.

Changing back to using `pthread_self()` fixes the issue. I don't think standard C++ mechanisms can be used here to set the thread priority until the C++ standard introduces a mechanism to get the native handle to the current thread.