### PR TITLE
Bug fixes in modbusmaster

### DIFF
--- a/runtime/core/modbusmaster/master.h
+++ b/runtime/core/modbusmaster/master.h
@@ -78,7 +78,7 @@ struct MasterConfig
     char ip_address[MASTER_ITEM_SIZE];
     /// The port (if using TCP).
     std::uint16_t ip_port;
-    std::uint16_t rtu_baud_rate;
+    std::uint32_t rtu_baud_rate;
     std::uint8_t rtu_parity;
     std::uint16_t rtu_data_bit;
     std::uint16_t rtu_stop_bit;  

--- a/runtime/core/modbusmaster/master_indexed.cpp
+++ b/runtime/core/modbusmaster/master_indexed.cpp
@@ -265,7 +265,7 @@ void* oplc::modbusm::modbus_master_indexed_poll(void* args)
             {
                 {
                     lock_guard<mutex> guard(io_lock);
-                    bool_output_buf.copy_from_cache(rw_buffer, mapping->coils.num_regs, mapping->coils.buffer_offset);
+                    bool_output_buf.copy_from_cache(rw_buffer, mapping->coils.buffer_offset, mapping->coils.num_regs);
                 }
 
                 nanosleep(&ts, NULL); 

--- a/runtime/core/modbusmaster/master_indexed.cpp
+++ b/runtime/core/modbusmaster/master_indexed.cpp
@@ -377,7 +377,7 @@ void assign_mappings(const GlueVariablesBinding& bindings)
             for (auto i = 0; i < 8; ++i)
             {
                 auto offset = glue_var.msi - MAPPED_GLUE_START;
-                bool_input_buf.assign(offset * 8 + i, group->values[i]);
+                bool_output_buf.assign(offset * 8 + i, group->values[i]);
             }
         }
         else if (glue_var.dir == IECLDT_IN && glue_var.size == IECLST_BIT)
@@ -387,7 +387,7 @@ void assign_mappings(const GlueVariablesBinding& bindings)
             for (auto i = 0; i < 8; ++i)
             {
                 auto offset = glue_var.msi - MAPPED_GLUE_START;
-                bool_output_buf.assign(offset * 8 + i, group->values[i]);
+                bool_input_buf.assign(offset * 8 + i, group->values[i]);
             }
         }
     }


### PR DESCRIPTION
Hi!

This PR fixes three bugs in the modbusmaster runtime.

1. Baud rates for Serial interfaces often exceed the maximum uint16_t value -> change to uint32_t in master.h.
2. Arguments to copy_from_cache are swapped in master_indexed.cpp
3. bool_input_buf and bool_output_buf are swapped in master_indexed.cpp

With these changes i was able to run the demo project for Arduino Uno.

Best regards
Johannes