### PR TITLE
WORKING_DIR pointed to the incorrect folder.

### DIFF
--- a/background_installer.sh
+++ b/background_installer.sh
@@ -19,6 +19,7 @@ if [ $# -eq 0 ]; then
     exit 1
 fi
 
+WORKING_DIR=$(pwd)
 mkdir -p bin
 touch etc/Config0.c
 touch etc/Res0.c
@@ -43,7 +44,6 @@ function install_py_deps {
 function OPLC_background_service {
     echo ""
     echo "[OPENPLC SERVICE]"
-    WORKING_DIR=$(pwd)
     echo -e "[Unit]\nDescription=OpenPLC Service\nAfter=network.target\n\n[Service]\nType=simple\nRestart=always\nRestartSec=1\nUser=root\nGroup=root\nWorkingDirectory=$WORKING_DIR\nExecStart=$WORKING_DIR/start_openplc.sh\n\n[Install]\nWantedBy=multi-user.target" >> openplc.service
     $1 cp -rf ./openplc.service /lib/systemd/system/
     rm -rf openplc.service


### PR DESCRIPTION
The function "OPLC_background_service" assigns **$WORKING_DIR** to **$(pwd)/_bin_** and creates the incorrect pointer to the  start_openplc.sh service script.  Upon bootup I got the following:

May 29 19:42:14 pi1 systemd[563]: openplc.service: Failed to execute command: No such file or directory
May 29 19:42:14 pi1 systemd[563]: openplc.service: Failed at step EXEC spawning /home/pi/dev/OpenPLC_v3/bin/start_openplc.sh: **No such file or directory**

The startup script is in:
/home/pi/dev/OpenPLC_v3/start_openplc.sh
not in
/home/pi/dev/OpenPLC_v3/**bin**/start_openplc.sh

