### PR TITLE
Improve input sanitation by escaping possible HTML characters in order to prevent the embedding of custom JavasScript

### DIFF
--- a/webserver/webserver.py
+++ b/webserver/webserver.py
@@ -2323,7 +2323,7 @@ def create_connection(db_file):
 
 
 #----------------------------------------------------------------------------
-#Returns a generator that returns the sanitized arguments.
+#Returns a generator that yields the sanitized arguments.
 #----------------------------------------------------------------------------
 def sanitize_input(*args):
    return (escape(a) for a in args)

--- a/webserver/webserver.py
+++ b/webserver/webserver.py
@@ -891,6 +891,8 @@ def upload_program_action():
         prog_descr = flask.request.form['prog_descr']
         prog_file = flask.request.form['prog_file']
         epoch_time = flask.request.form['epoch_time']
+
+        (prog_name, prog_descr, prog_file, epoch_time) = sanitize_input(prog_name, prog_descr, prog_file, epoch_time)
         
         database = "openplc.db"
         conn = create_connection(database)
@@ -1155,6 +1157,9 @@ def add_modbus_device():
             aow_start = flask.request.form.get('aow_start')
             aow_size = flask.request.form.get('aow_size')
             
+            (devname, devtype, devid, devcport, devbaud, devparity, devdata, devstop, devip, devport, di_start, di_size, do_start, do_size, ai_start, ai_size, aor_start, aor_size, aow_start, aow_size) \
+                = sanitize_input(devname, devtype, devid, devcport, devbaud, devparity, devdata, devstop, devip, devport, di_start, di_size, do_start, do_size, ai_start, ai_size, aor_start, aor_size, aow_start, aow_size)
+
             database = "openplc.db"
             conn = create_connection(database)
             if (conn != None):
@@ -1325,6 +1330,9 @@ def modbus_edit_device():
             aow_start = flask.request.form.get('aow_start')
             aow_size = flask.request.form.get('aow_size')
             
+            (devname, devtype, devid, devcport, devbaud, devparity, devdata, devstop, devip, devport, di_start, di_size, do_start, do_size, ai_start, ai_size, aor_start, aor_size, aow_start, aow_size, devid_db) \
+                = sanitize_input(devname, devtype, devid, devcport, devbaud, devparity, devdata, devstop, devip, devport, di_start, di_size, do_start, do_size, ai_start, ai_size, aor_start, aor_size, aow_start, aow_size, devid_db)
+
             database = "openplc.db"
             conn = create_connection(database)
             if (conn != None):
@@ -1845,6 +1853,9 @@ def add_user():
             username = flask.request.form['user_name']
             email = flask.request.form['user_email']
             password = flask.request.form['user_password']
+
+            (name, username, email) = sanitize_input(name, username, email)
+
             form_has_picture = True
             if ('file' not in flask.request.files):
                 form_has_picture = False
@@ -1973,6 +1984,7 @@ def edit_user():
             username = flask.request.form['user_name']
             email = flask.request.form['user_email']
             password = flask.request.form['user_password']
+            (user_id, name, username, email) = sanitize_input(user_id, name, username, email)
             form_has_picture = True
             if ('file' not in flask.request.files):
                 form_has_picture = False
@@ -2221,6 +2233,8 @@ def settings():
             slave_polling = flask.request.form.get('slave_polling_period')
             slave_timeout = flask.request.form.get('slave_timeout')
             
+            (modbus_port, dnp3_port, enip_port, pstorage_poll, start_run, slave_polling, slave_timeout) = sanitize_input(modbus_port, dnp3_port, enip_port, pstorage_poll, start_run, slave_polling, slave_timeout)
+
             database = "openplc.db"
             conn = create_connection(database)
             if (conn != None):
@@ -2306,6 +2320,40 @@ def create_connection(db_file):
       print(e)
 
    return None
+
+
+#----------------------------------------------------------------------------
+#Returns a generator that returns the sanitized arguments.
+#----------------------------------------------------------------------------
+def sanitize_input(*args):
+   return (escape(a) for a in args)
+
+#----------------------------------------------------------------------------
+# Taken from the html module of the python 3.9 standard library
+# exact lines of code can be found here:
+# https://github.com/python/cpython/blob/3.9/Lib/html/__init__.py#L12
+# Modified to convert to String but preserve NoneType.
+# Preserving NoneType is necessary to ensure program logic is not affected by None being converted to "None",
+# this is relevant in setttings()
+#----------------------------------------------------------------------------
+def escape(s, quote=True):
+    """
+    Replace special characters "&", "<" and ">" to HTML-safe sequences.
+    If the optional flag quote is true (the default), the quotation mark
+    characters, both double quote (") and single quote (') characters are also
+    translated.
+    """
+    if s is None: 
+        return s
+    s = str(s) # force string
+    s = s.replace("&", "&amp;") # Must be done first!
+    s = s.replace("<", "&lt;")
+    s = s.replace(">", "&gt;")
+    if quote:
+        s = s.replace('"', "&quot;")
+        s = s.replace('\'', "&#x27;")
+    return s
+
 
 #----------------------------------------------------------------------------
 #Main dummy function. Only displays a message and exits. The app keeps


### PR DESCRIPTION
## Issue

Currently, the input from forms can include JavaScript that is not escaped in order to prevent its execution.

For instance, it was possible to upload a program with the description:
```html
<script>alert('xss');</script>
```
The code in the script tag is then executed. The same issue applies to many other fields.

## Solution

I added some sanitation. 
The sanitation consists of using a [slightly modified version](https://github.com/vembacher/OpenPLC_v3/blob/f61bfa7d5ed201859d82b7e00c601922835ad554/webserver/webserver.py#L2339) of `html.escape` [from the python 3.9 standard library](https://github.com/python/cpython/blob/3.9/Lib/html/__init__.py#L12).

The sanitation is applied when creating/updating data in the database with user provided input.
