### PR TITLE
Connection status issues resolved

### DIFF
--- a/webserver/core/modbus_master.cpp
+++ b/webserver/core/modbus_master.cpp
@@ -60,7 +60,7 @@ struct MB_address
 
 struct MB_device
 {
-    modbus_t *mb_ctx;
+	modbus_t *mb_ctx;
     char dev_name[100];
     uint8_t protocol;
     char dev_address[100];
@@ -70,7 +70,7 @@ struct MB_device
     int rtu_data_bit;
     int rtu_stop_bit;
     uint8_t dev_id;
-    bool isConnected;
+	bool isConnected;
 
     struct MB_address discrete_inputs;
     struct MB_address coils;
@@ -166,7 +166,8 @@ void parseConfig()
                     char temp_buffer[5];
                     getData(line_str, temp_buffer, '"', '"');
                     num_devices = atoi(temp_buffer);
-                    mb_devices = (struct MB_device *)malloc(num_devices*sizeof(struct MB_device));
+					//initializes the allocated memory to zero
+					mb_devices = calloc(num_devices, sizeof(struct MB_device));
                 }
                 else if (!strncmp(line_str, "Polling_Period", 14))
                 {
@@ -355,30 +356,31 @@ void *querySlaveDevices(void *arg)
 
         for (int i = 0; i < num_devices; i++)
         {
-            //Check if there is a device using the same port
-            bool found_sharing = false;
-            for (int a = 0; a < num_devices; a++)
-            {
-                if (a != i && !strcmp(mb_devices[i].dev_address, mb_devices[a].dev_address))
-                {
-                    found_sharing = true;
-                    if (mb_devices[i].isConnected == false && mb_devices[a].isConnected == true)
-                    {
-                        mb_devices[i].mb_ctx = mb_devices[a].mb_ctx;
-                        sprintf(log_msg, "Connected to MB device %s\n", mb_devices[i].dev_name);
-                        log(log_msg);
-                        mb_devices[i].isConnected = true;
-                    }
-                }
-            }
-            if (found_sharing)
-            {
-                //Must reset mb context to current device's slave id
-                modbus_set_slave(mb_devices[i].mb_ctx, mb_devices[i].dev_id);
-            }
+            //Check if there is a connected RTU device using the same port
+			bool found_sharing = false;
+            bool rtu_connected = false;
+			if (mb_devices[i].protocol == MB_RTU)
+			{
+				for (int a = 0; a < num_devices; a++)
+				{
+					if (a != i && !strcmp(mb_devices[i].dev_address, mb_devices[a].dev_address))
+					{
+						found_sharing = true;
+						if (mb_devices[a].isConnected)
+						{
+							rtu_port_connected = true;
+						}
+					}
+				}
+				if (found_sharing)
+				{
+					//Must reset mb context to current device's slave id
+					modbus_set_slave(mb_devices[i].mb_ctx, mb_devices[i].dev_id);
+				}
+			}
 
             //Verify if device is connected
-            if (!mb_devices[i].isConnected)
+            if (!mb_devices[i].isConnected && !rtu_port_connected)
             {
                 sprintf(log_msg, "Device %s is disconnected. Attempting to reconnect...\n", mb_devices[i].dev_name);
                 log(log_msg);
@@ -404,7 +406,7 @@ void *querySlaveDevices(void *arg)
                     mb_devices[i].isConnected = true;
                 }
             }
-            if (mb_devices[i].isConnected)
+            if (mb_devices[i].isConnected || rtu_port_connected)
             {
 
                 struct timespec ts;
@@ -602,10 +604,34 @@ void initializeMB()
         }
         else if (mb_devices[i].protocol == MB_RTU)
         {
-            mb_devices[i].mb_ctx = modbus_new_rtu(    mb_devices[i].dev_address, mb_devices[i].rtu_baud,
-                                                    mb_devices[i].rtu_parity, mb_devices[i].rtu_data_bit,
-                                                    mb_devices[i].rtu_stop_bit);
-
+			//Check if there is a device using the same port
+			int share_index = -1;
+            for (int a = 0; a < num_devices && a < i; a++)
+            {
+                if (strcmp(mb_devices[i].dev_address, mb_devices[a].dev_address) == 0)
+                {
+					share_index = a;
+					break;
+				}
+					
+            }
+			if (share_index != -1)
+			{
+				if (mb_devices[i].rtu_baud != mb_devices[share_index].rtu_baud || mb_devices[i].rtu_parity != mb_devices[share_index].rtu_parity || 
+					mb_devices[i].rtu_data_bit != mb_devices[share_index].rtu_data_bit || mb_devices[i].rtu_stop_bit != mb_devices[share_index].rtu_stop_bit)
+				{
+					unsigned char log_msg[1000];
+					sprintf(log_msg, "Warning MB device %s port setting missmatch\n", mb_devices[i].dev_name);
+					log(log_msg);
+				}
+				mb_devices[i].mb_ctx = mb_devices[share_index].mb_ctx;
+            }
+			else
+			{
+				mb_devices[i].mb_ctx = modbus_new_rtu(mb_devices[i].dev_address, mb_devices[i].rtu_baud,
+												mb_devices[i].rtu_parity, mb_devices[i].rtu_data_bit,
+												mb_devices[i].rtu_stop_bit);
+			}
         }
         
         //slave id

--- a/webserver/core/modbus_master.cpp
+++ b/webserver/core/modbus_master.cpp
@@ -358,7 +358,7 @@ void *querySlaveDevices(void *arg)
         {
             //Check if there is a connected RTU device using the same port
 			bool found_sharing = false;
-            bool rtu_connected = false;
+            bool rtu_port_connected = false;
 			if (mb_devices[i].protocol == MB_RTU)
 			{
 				for (int a = 0; a < num_devices; a++)


### PR DESCRIPTION
Hi. I fixed a issues with RTU devices. Using calloc instead of malloc makes shore that isConnected in MB_device is false on initialization.
Also moved the part that handles multiple RTU devices to initializeMB so that modbus_new_rtu is called only once for every port making shore that port settings and connections status is handled consistent.

Fixes thiagoralves/OpenPLC_v3#150