### PR TITLE
Dockerfile: simplify by reordering WORKDIR line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye-20211201
 
 COPY . /workdir
-RUN cd /workdir && ./install.sh docker
 WORKDIR /workdir
+RUN ./install.sh docker
 ENTRYPOINT ["./start_openplc.sh"]


### PR DESCRIPTION
Moving `WORKDIR` before the `./install.sh` command, there is no need for the `cd` command.