### PR TITLE
Dockerfile: Use specific base image tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian
+FROM debian:bullseye-20211201
 
 COPY . /workdir
 RUN cd /workdir && ./install.sh docker


### PR DESCRIPTION
In accordance with container security best practices, specify the base image tag.
