### PR TITLE
Parse ST file upon webserver starts up

### DIFF
--- a/webserver/webserver.py
+++ b/webserver/webserver.py
@@ -2401,6 +2401,7 @@ if __name__ == '__main__':
                 openplc_runtime.start_runtime()
                 time.sleep(1)
                 configure_runtime()
+		monitor.parse_st(openplc_runtime.project_file)
             
             app.run(debug=False, host='0.0.0.0', threaded=True, port=8080)
         


### PR DESCRIPTION
When OpenPLC starts in RUN mode, monitoring page shows blank when webserver (./start_openplc.sh) is restarted. To fix the issue, ST file should be parsed when openplc_runtime starts.