### PR TITLE
Add docker instructions for Linux Mint 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Where `[platform]` can be:
 `custom` - Skip all specific package installation and tries to install OpenPLC assuming your system already has all dependencies met. This option can be useful if you're trying to install OpenPLC on an unsuported Linux platform or had manually installed all the dependency packages before.
 
 ### Building, Installing and Running inside Docker
-Make sure [`docker` is installed](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
+When using Ubuntu       : make sure [`docker` is installed](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
+When using Linux Mint 21: make sure [`docker` is installed](https://computingforgeeks.com/install-docker-docker-compose-on-linux-mint/)
 
 #### Build
 ```


### PR DESCRIPTION
The default instructions are for Ubuntu.  However, I'm using Linux Mint 21 and had issues when following the Ubuntu guidelines until I stumbled upon the new link added to the README.md file.
This works flawlessly on the Linux Mint 21 distro now and might be useful for other too.