### PR TITLE
RPi HW layer compiles correctly now

### DIFF
--- a/background_installer.sh
+++ b/background_installer.sh
@@ -348,7 +348,7 @@ elif [ "$1" == "rpi" ]; then
     echo ""
     echo "[FINALIZING]"
     cd webserver/scripts
-    ./change_hardware_layer.sh rpi
+    ./change_hardware_layer.sh blank_linux
     ./compile_program.sh blank_program.st
     cp ./start_openplc.sh ../../
 

--- a/background_installer.sh
+++ b/background_installer.sh
@@ -348,7 +348,7 @@ elif [ "$1" == "rpi" ]; then
     echo ""
     echo "[FINALIZING]"
     cd webserver/scripts
-    ./change_hardware_layer.sh blank_linux
+    ./change_hardware_layer.sh rpi
     ./compile_program.sh blank_program.st
     cp ./start_openplc.sh ../../
 

--- a/webserver/core/hardware_layers/raspberrypi.cpp
+++ b/webserver/core/hardware_layers/raspberrypi.cpp
@@ -74,7 +74,7 @@ void initializeHardware()
 	//set pins as input
 	for (int i = 0; i < MAX_INPUT; i++)
 	{
-	    if (pinNotPresent(ignored_bool_inputs, ARRAY_SIZE(ignored_bool_inputs), i))
+	    if (pinNotPresent(ignored_bool_inputs, ARRAY_SIZE(ignored_bool_inputs), inBufferPinMask[i]))
 	    {
 		    pinMode(inBufferPinMask[i], INPUT);
 		    if (i != 0 && i != 1) //pull down can't be enabled on the first two pins
@@ -87,14 +87,14 @@ void initializeHardware()
 	//set pins as output
 	for (int i = 0; i < MAX_OUTPUT; i++)
 	{
-	    if (pinNotPresent(ignored_bool_outputs, ARRAY_SIZE(ignored_bool_outputs), i))
+	    if (pinNotPresent(ignored_bool_outputs, ARRAY_SIZE(ignored_bool_outputs), outBufferPinMask[i]))
 	    	pinMode(outBufferPinMask[i], OUTPUT);
 	}
 
 	//set PWM pins as output
 	for (int i = 0; i < MAX_ANALOG_OUT; i++)
 	{
-	    if (pinNotPresent(ignored_int_outputs, ARRAY_SIZE(ignored_int_outputs), i))
+	    if (pinNotPresent(ignored_int_outputs, ARRAY_SIZE(ignored_int_outputs), analogOutBufferPinMask[i]))
     		pinMode(analogOutBufferPinMask[i], PWM_OUTPUT);
 	}
 }
@@ -119,7 +119,7 @@ void updateBuffersIn()
 	//INPUT
 	for (int i = 0; i < MAX_INPUT; i++)
 	{
-	    if (pinNotPresent(ignored_bool_inputs, ARRAY_SIZE(ignored_bool_inputs), i))
+	    if (pinNotPresent(ignored_bool_inputs, ARRAY_SIZE(ignored_bool_inputs), inBufferPinMask[i]))
     		if (bool_input[i/8][i%8] != NULL) *bool_input[i/8][i%8] = digitalRead(inBufferPinMask[i]);
 	}
 
@@ -138,7 +138,7 @@ void updateBuffersOut()
 	//OUTPUT
 	for (int i = 0; i < MAX_OUTPUT; i++)
 	{
-	    if (pinNotPresent(ignored_bool_outputs, ARRAY_SIZE(ignored_bool_outputs), i))
+	    if (pinNotPresent(ignored_bool_outputs, ARRAY_SIZE(ignored_bool_outputs), outBufferPinMask[i]))
     		if (bool_output[i/8][i%8] != NULL) digitalWrite(outBufferPinMask[i], *bool_output[i/8][i%8]);
 	}
 


### PR DESCRIPTION
Currently, the RPi HW layer file is not compiled at all since the `background_installer` script was invoking the `change_hardware_layer` script incorrectly.  The parameter `blank_script` was passed instead of the parameter `rpi`.
Due to this change, the file `raspberrypi.cpp` is now compiled (was not in the past, it was just the empty blank file) **and** installed when running the compilation script `./install.sh` with the argument `rpi`.

Next to this, the content of the file `raspberrypi.cpp` was wrong.  When iterating over the arrays, the index parameter `i` of the `for`-loop was passed to the function `pinNotPresent()` instead of the item at location `i` of the corresponding array.  This has been corrected, is tested and works perfect now.