### PR TITLE
webserver/core/main.cpp: Get REAL-TIME time values

### DIFF
--- a/webserver/core/main.cpp
+++ b/webserver/core/main.cpp
@@ -80,6 +80,22 @@ void sleepms(int milliseconds)
 	nanosleep(&ts, NULL);
 }
 
+/**
+ * @fn timespec_diff(struct timespec *, struct timespec *, struct timespec *)
+ * @brief Compute the diff of two timespecs, that is a - b = result.
+ * @param a the minuend
+ * @param b the subtrahend
+ * @param result a - b
+ */
+static inline void timespec_diff(struct timespec *a, struct timespec *b, struct timespec *result) {
+    result->tv_sec  = a->tv_sec  - b->tv_sec;
+    result->tv_nsec = a->tv_nsec - b->tv_nsec;
+    if (result->tv_nsec < 0) {
+        --result->tv_sec;
+        result->tv_nsec += 1000000000L;
+    }
+}
+
 //-----------------------------------------------------------------------------
 // Helper function - Logs messages and print them on the console
 //-----------------------------------------------------------------------------
@@ -184,6 +200,15 @@ void handleSpecialFunctions()
     //insert other special functions below
 }
 
+//-----------------------------------------------------------------------------
+// Using special_functions to store REAL-TIME variables
+//-----------------------------------------------------------------------------
+void RecordCycletimeLatency(long cycle_time, long sleep_latency)
+{
+    if (special_functions[4] != NULL) *special_functions[4] = cycle_time;
+    if (special_functions[5] != NULL) *special_functions[5] = sleep_latency;
+}
+
 // pointers to IO *array[const][const] from cpp to c and back again don't work as expected, so instead callbacks
 u_int8_t *bool_input_call_back(int a, int b){ return bool_input[a][b]; }
 u_int8_t *bool_output_call_back(int a, int b){ return bool_output[a][b]; }
@@ -195,6 +220,16 @@ void logger_callback(unsigned char *msg){ log(msg);}
 
 int main(int argc,char **argv)
 {
+    // Define the max/min/avg/total cycle and latency variables used in REAL-TIME computation(in nanoseconds)
+    long cycle_avg, cycle_max, cycle_min, cycle_total;
+    long latency_avg, latency_max, latency_min, latency_total;
+    cycle_max = 0;
+    cycle_min = LONG_MAX;
+    cycle_total = 0;
+    latency_max = 0;
+    latency_min = LONG_MAX;
+    latency_total = 0;
+
     unsigned char log_msg[1000];
     sprintf((char *)log_msg, "OpenPLC Runtime starting...\n");
     log(log_msg);
@@ -265,9 +300,12 @@ int main(int argc,char **argv)
     }
 #endif
 
+	// Define the start, end, cycle time and latency time variables
+	struct timespec cycle_start, cycle_end, cycle_time;
+	struct timespec timer_start, timer_end, sleep_latency;
+
 	//gets the starting point for the clock
 	printf("Getting current time\n");
-	struct timespec timer_start;
 	clock_gettime(CLOCK_MONOTONIC, &timer_start);
 
 	//======================================================
@@ -275,6 +313,9 @@ int main(int argc,char **argv)
 	//======================================================
 	while(run_openplc)
 	{
+		// Get the start time for the running cycle
+		clock_gettime(CLOCK_MONOTONIC, &cycle_start);
+
 		//make sure the buffer pointers are correct and
 		//attached to the user variables
 		glueVars();
@@ -317,8 +358,39 @@ int main(int argc,char **argv)
         
 		updateTime();
 
+		// Get the end time for the running cycle
+		clock_gettime(CLOCK_MONOTONIC, &cycle_end);
+		// Compute the time usage in one cycle and do max/min/total comparison/recording
+		timespec_diff(&cycle_end, &cycle_start, &cycle_time);
+		if (cycle_time.tv_nsec > cycle_max)
+			cycle_max = cycle_time.tv_nsec;
+		if (cycle_time.tv_nsec < cycle_min)
+			cycle_min = cycle_time.tv_nsec;
+		cycle_total = cycle_total + cycle_time.tv_nsec;
+
 		sleep_until(&timer_start, common_ticktime__);
+
+		// Get the sleep end point which is also the start time/point of the next cycle
+		clock_gettime(CLOCK_MONOTONIC, &timer_end);
+		// Compute the time latency of the next cycle(caused by sleep) and do max/min/total comparison/recording
+		timespec_diff(&timer_end, &timer_start, &sleep_latency);
+		if (sleep_latency.tv_nsec > latency_max)
+			latency_max = sleep_latency.tv_nsec;
+		if (sleep_latency.tv_nsec < latency_min)
+			latency_min = sleep_latency.tv_nsec;
+		latency_total = latency_total + sleep_latency.tv_nsec;
+
+		// Store the cycle_time/sleep_latency in microsecond, so it can be displayed in the webpage
+		RecordCycletimeLatency((long)cycle_time.tv_nsec / 1000, (long)sleep_latency.tv_nsec / 1000);
 	}
+
+	// Compute/print the max/min/avg cycle time and latency
+	cycle_avg = (long)cycle_total / __tick;
+	latency_avg = (long)latency_total / __tick;
+	printf("###Summary: The maximum/minimum/average cycle time in microsecond is %ld/%ld/%ld\n",
+	cycle_max / 1000, cycle_min / 1000, cycle_avg / 1000);
+	printf("###Summary: The maximum/minimum/average latency in microsecond is %ld/%ld/%ld\n",
+	latency_max / 1000,   latency_min / 1000, latency_avg / 1000);
     
     //======================================================
 	//             SHUTTING DOWN OPENPLC RUNTIME


### PR DESCRIPTION
Add code to get the real time cycle time and latency, the maximum/minimum/average values would be printed out in the logs as a summary at the end of the OpenPLC running. The following diagram describes the logic.

"|": Beginning of execution of the PLC code
"s": Start of execution of PLC code
"e": End of execution of PLC code

Therefore, the time interval between two "|" symbols is usually 20ms by default(defined in OpenPLC Editor program), while "timeof(e) - timeof(s)" represents the cycle time and "timeof(s) - timeof(|)" represents the latency after sleep.

|_s____e______|__s___e______|s_____e______|_____________|


Also a new function RecordCycletimeLatency() was added which uses special_function[[4]](%ML1028) and special_function[[5]](%ML1029) to store the cycle time and latency in the running OpenPLC cycle, so in the webpage they can be displayed if necessary.


Thanks my colleagues Alexander Lougovski, Marcelo Tosatti and Wenkang Ji a lot for the initiating, ideas and help.