### PR TITLE
Rework installer

### DIFF
--- a/background_installer.sh
+++ b/background_installer.sh
@@ -160,6 +160,12 @@ function install_libmodbus {
     fi
     $1 ldconfig
     cd "$OPENPLC_DIR"
+
+    # Fix for RPM-based distros
+    if [ -x /bin/yum ]; then
+        sudo cp /usr/local/lib/pkgconfig/libmodbus.pc /usr/share/pkgconfig/
+        sudo cp /usr/local/lib/lib*.* /lib64/
+    fi
 }
 
 function install_systemd_service() {
@@ -286,13 +292,6 @@ elif [ "$1" == "linux" ]; then
 
     install_all_libs sudo
     install_systemd_service sudo
-
-    # Fix for RPM-based distros
-    if [ -x /bin/yum ]; then
-        sudo cp /usr/local/lib/pkgconfig/libmodbus.pc /usr/share/pkgconfig/
-        sudo cp /usr/local/lib/lib*.* /lib64/
-    fi
-    
     finalize_install
 
 elif [ "$1" == "docker" ]; then

--- a/background_installer.sh
+++ b/background_installer.sh
@@ -102,13 +102,15 @@ function install_glue_generator {
 }
 
 function install_ethercat {
-    if [ "$ETHERCAT_INSTALL" == "install" ]; then
-        echo ""
-        echo "[EtherCAT]"
-        cd "$OPENPLC_DIR/utils/ethercat_src"
-        ./install.sh || fail "Error compiling EtherCAT"
-    fi
+    echo "[EtherCAT]"
+    cd "$OPENPLC_DIR/utils/ethercat_src"
+    ./install.sh || fail "Error compiling EtherCAT"
+    echo ethercat > "$OPENPLC_DIR/webserver/scripts/ethercat"
     cd "$OPENPLC_DIR"
+}
+
+function disable_ethercat {
+    echo "" > "$OPENPLC_DIR/webserver/scripts/ethercat"
 }
 
 function install_opendnp3 {
@@ -185,6 +187,7 @@ function install_all_libs {
     install_st_optimizer "$1"
     install_glue_generator "$1"
     install_opendnp3 "$1"
+    disable_ethercat "$1"
     install_libmodbus "$1"
 }
 
@@ -243,19 +246,13 @@ if [ "$1" == "win" ]; then
 elif [ "$1" == "linux" ]; then
 
     echo "Installing OpenPLC on Linux"
-    if [ "$2" == "ethercat" ]; then
-        echo "including EtherCAT"
-        ETHERCAT_INSTALL="install"
-        echo ethercat > webserver/scripts/ethercat
-    else
-        echo "" > webserver/scripts/ethercat
-    fi
     linux_install_deps sudo
     
     install_py_deps
     install_py_deps "sudo -H"
 
     install_all_libs sudo
+    [ "$2" == "ethercat" ] && install_ethercat
     install_systemd_service sudo
     finalize_install
 

--- a/background_installer.sh
+++ b/background_installer.sh
@@ -24,6 +24,12 @@ function print_help_and_exit {
 
 [ $# -eq 0 ] && print_help_and_exit
 
+function fail {
+    echo "$*"
+    echo "OpenPLC was NOT installed!"
+    exit 1
+}
+
 #set -x 
 # arg1: sudo or blank
 function linux_install_deps {
@@ -39,8 +45,7 @@ function linux_install_deps {
                               automake libtool make git python2.7 \
                               sqlite3 cmake git curl python3 python3-pip libmodbus-dev
     else
-        echo "Unsupported linux distro."
-        exit 1
+        fail "Unsupported linux distro."
     fi
     curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
     $1 python2.7 get-pip.py
@@ -78,38 +83,21 @@ function install_matiec {
     autoreconf -i
     ./configure
     make
-    cp ./iec2c "$OPENPLC_DIR/webserver/"
-    if [ $? -ne 0 ]; then
-        echo "Error compiling MatIEC"
-        echo "OpenPLC was NOT installed!"
-        exit 1
-    fi
+    cp ./iec2c "$OPENPLC_DIR/webserver/" || fail "Error compiling MatIEC"
     cd "$OPENPLC_DIR"
 }
 
 function install_st_optimizer {
     echo "[ST OPTIMIZER]"
     cd "$OPENPLC_DIR/utils/st_optimizer_src"
-    g++ st_optimizer.cpp -o st_optimizer
-    cp ./st_optimizer "$OPENPLC_DIR/webserver/"
-    if [ $? -ne 0 ]; then
-        echo "Error compiling ST Optimizer"
-        echo "OpenPLC was NOT installed!"
-        exit 1
-    fi
+    g++ st_optimizer.cpp -o "$OPENPLC_DIR/webserver/st_optimizer" || fail "Error compiling ST Optimizer"
     cd "$OPENPLC_DIR"
 }
 
 function install_glue_generator {
     echo "[GLUE GENERATOR]"
     cd "$OPENPLC_DIR/utils/glue_generator_src"
-    g++ -std=c++11 glue_generator.cpp -o glue_generator
-    cp ./glue_generator "$OPENPLC_DIR/webserver/core"
-    if [ $? -ne 0 ]; then
-        echo "Error compiling Glue Generator"
-        echo "OpenPLC was NOT installed!"
-        exit 1
-    fi
+    g++ -std=c++11 glue_generator.cpp -o "$OPENPLC_DIR/webserver/core/glue_generator" || fail "Error compiling Glue Generator"
     cd "$OPENPLC_DIR"
 }
 
@@ -118,12 +106,7 @@ function install_ethercat {
         echo ""
         echo "[EtherCAT]"
         cd "$OPENPLC_DIR/utils/ethercat_src"
-        ./install.sh
-        if [ $? -ne 0 ]; then
-            echo "Error compiling EtherCAT"
-            echo "OpenPLC was NOT installed!"
-            exit 1
-        fi
+        ./install.sh || fail "Error compiling EtherCAT"
     fi
     cd "$OPENPLC_DIR"
 }
@@ -134,12 +117,7 @@ function install_opendnp3 {
     swap_on
     cmake .
     make
-    $1 make install
-    if [ $? -ne 0 ]; then
-        echo "Error installing OpenDNP3"
-        echo "OpenPLC was NOT installed!"
-        exit 1
-    fi
+    $1 make install || fail "Error installing OpenDNP3"
     $1 ldconfig
     swap_off
     cd "$OPENPLC_DIR"
@@ -152,12 +130,7 @@ function install_libmodbus {
     cd "$OPENPLC_DIR/utils/libmodbus_src"
     ./autogen.sh
     ./configure
-    $1 make install
-    if [ $? -ne 0 ]; then
-        echo "Error installing Libmodbus"
-        echo "OpenPLC was NOT installed!"
-        exit 1
-    fi
+    $1 make install || fail "Error installing Libmodbus"
     $1 ldconfig
     cd "$OPENPLC_DIR"
 
@@ -255,20 +228,10 @@ if [ "$1" == "win" ]; then
     echo "[OPEN DNP3]"
     cd "$OPENPLC_DIR/webserver/core"
     if test -f dnp3.cpp; then
-        mv dnp3.cpp dnp3.disabled
-        if [ $? -ne 0 ]; then
-            echo "Error disabling OpenDNP3"
-            echo "OpenPLC was NOT installed!"
-            exit 1
-        fi
+        mv dnp3.cpp dnp3.disabled || fail "Error disabling OpenDNP3"
     fi
     if test -f dnp3_dummy.disabled; then
-        mv dnp3_dummy.disabled dnp3_dummy.cpp
-        if [ $? -ne 0 ]; then
-            echo "Error disabling OpenDNP3"
-            echo "OpenPLC was NOT installed!"
-            exit 1
-        fi
+        mv dnp3_dummy.disabled dnp3_dummy.cpp || fail "Error disabling OpenDNP3"
     fi
     cd "$OPENPLC_DIR"
 

--- a/background_installer.sh
+++ b/background_installer.sh
@@ -181,7 +181,6 @@ function install_all_libs {
     install_glue_generator "$1"
     install_opendnp3 "$1"
     install_libmodbus "$1"
-    install_systemd_service "$1"
 }
 
 function finalize_install { (
@@ -272,7 +271,8 @@ elif [ "$1" == "linux" ]; then
     install_py_deps "sudo -H"
 
     install_all_libs sudo
-    
+    install_systemd_service sudo
+
     #Detecting OS type
     OS_TYPE=""
     OS=$(awk '/NAME=/' /etc/*-release | sed -n '1 p' | cut -d= -f2 | cut -d\" -f2 | cut -d" " -f1)
@@ -295,7 +295,6 @@ elif [ "$1" == "linux" ]; then
     
     finalize_install
 
-
 elif [ "$1" == "docker" ]; then
     echo "Installing OpenPLC on Linux inside Docker"
     linux_install_deps
@@ -313,6 +312,7 @@ elif [ "$1" == "rpi" ]; then
     install_py_deps "sudo -H" 
 
     install_all_libs sudo
+    install_systemd_service sudo
     finalize_install
 
 elif [ "$1" == "neuron" ]; then
@@ -333,11 +333,13 @@ elif [ "$1" == "neuron" ]; then
     install_py_deps "sudo -H"
 
     install_all_libs sudo
+    install_systemd_service sudo
     finalize_install
 
 elif [ "$1" == "custom" ]; then
     echo "Installing OpenPLC on Custom Platform"
     install_all_libs
+    install_systemd_service sudo
     finalize_install
 
 else

--- a/background_installer.sh
+++ b/background_installer.sh
@@ -115,12 +115,12 @@ function disable_ethercat {
 function install_opendnp3 {
     echo "[OPEN DNP3]"
     cd "$OPENPLC_DIR/utils/dnp3_src"
-    swap_on
+    swap_on "$1"
     cmake .
     make
     $1 make install || fail "Error installing OpenDNP3"
     $1 ldconfig
-    swap_off
+    swap_off "$1"
     cd "$OPENPLC_DIR"
 }
 

--- a/background_installer.sh
+++ b/background_installer.sh
@@ -3,7 +3,7 @@ OPENPLC_DIR="$PWD"
 SWAP_FILE="$OPENPLC_DIR/swapfile"
 ETHERCAT_INSTALL=""
 
-if [ $# -eq 0 ]; then
+function print_help_and_exit {
     echo ""
     echo "Error: You must provide a platform name as argument"
     echo ""
@@ -20,7 +20,9 @@ if [ $# -eq 0 ]; then
     echo "                all the dependency packages before."
     echo ""
     exit 1
-fi
+}
+
+[ $# -eq 0 ] && print_help_and_exit
 
 #set -x 
 # arg1: sudo or blank
@@ -341,18 +343,5 @@ elif [ "$1" == "custom" ]; then
     finalize_install
 
 else
-    echo ""
-    echo "Error: unrecognized platform"
-    echo ""
-    echo "Usage: ./install.sh [platform]   where [platform] can be"
-    echo "  win           Install OpenPLC on Windows over Cygwin"
-    echo "  linux         Install OpenPLC on a Debian-based Linux distribution"
-    echo "  rpi           Install OpenPLC on a Raspberry Pi"
-    echo "  custom        Skip all specific package installation and tries to install"
-    echo "                OpenPLC assuming your system already has all dependencies met."
-    echo "                This option can be useful if you're trying to install OpenPLC"
-    echo "                on an unsuported Linux platform or had manually installed"
-    echo "                all the dependency packages before."
-    echo ""
-    exit 1
+    print_help_and_exit
 fi

--- a/background_installer.sh
+++ b/background_installer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 OPENPLC_DIR="$PWD"
-
+SWAP_FILE="$OPENPLC_DIR/swapfile"
 ETHERCAT_INSTALL=""
 
 if [ $# -eq 0 ]; then
@@ -54,15 +54,15 @@ function install_py_deps {
 
 function swap_on { (
     echo "creating swapfile..."
-    $1 dd if=/dev/zero of=swapfile bs=1M count=1000
-    $1 mkswap swapfile
-    $1 swapon swapfile
+    $1 dd if=/dev/zero of="$SWAP_FILE" bs=1M count=1000
+    $1 mkswap "$SWAP_FILE"
+    $1 swapon "$SWAP_FILE"
 ) }
 
 function swap_off { (
     echo "removing swapfile..."
-    $1 swapoff swapfile
-    $1 rm -f ./swapfile
+    $1 swapoff "$SWAP_FILE"
+    $1 rm -f "$SWAP_FILE"
 ) }
 
 function install_matiec { (

--- a/background_installer.sh
+++ b/background_installer.sh
@@ -155,22 +155,23 @@ function install_libmodbus { (
 function install_systemd_service() { (
     if [ "$1" == "sudo" ]; then
         echo "[OPENPLC SERVICE]"
-        WORKING_DIR=$(pwd)
-        echo -e "[Unit]\n\
-Description=OpenPLC Service\n\
-After=network.target\n\
-\n\
-[Service]\n\
-Type=simple\n\
-Restart=always\n\
-RestartSec=1\n\
-User=root\n\
-Group=root\n\
-WorkingDirectory=$WORKING_DIR\n\
-ExecStart=$WORKING_DIR/start_openplc.sh\n\
-\n\
-[Install]\n\
-WantedBy=multi-user.target" | $1 tee /lib/systemd/system/openplc.service > /dev/null
+        $1 tee /lib/systemd/system/openplc.service > /dev/null <<EOF
+[Unit]
+Description=OpenPLC Service
+After=network.target
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=1
+User=root
+Group=root
+WorkingDirectory=$OPENPLC_DIR
+ExecStart=$OPENPLC_DIR/start_openplc.sh
+
+[Install]
+WantedBy=multi-user.target
+EOF
         echo "Enabling OpenPLC Service..."
         $1 systemctl daemon-reload
         $1 systemctl enable openplc

--- a/background_installer.sh
+++ b/background_installer.sh
@@ -39,7 +39,7 @@ function linux_install_deps {
         $1 yum -q -y install curl make automake gcc gcc-c++ kernel-devel pkg-config bison flex autoconf libtool openssl-devel cmake python3 python3-pip
         $1 yum -q -y install python2.7 python2-devel
     #Installing dependencies for Ubuntu/Mint/Debian
-    elif [ -x /bin/apt-get ]; then
+    elif [ -x /usr/bin/apt-get ]; then
         $1 apt-get update
         $1 apt-get install -y build-essential pkg-config bison flex autoconf \
                               automake libtool make git python2.7 \

--- a/background_installer.sh
+++ b/background_installer.sh
@@ -184,6 +184,14 @@ function install_all_libs {
     install_systemd_service "$1"
 }
 
+function finalize_install { (
+    echo "[FINALIZING]"
+    cd "$OPENPLC_DIR/webserver/scripts"
+    ./change_hardware_layer.sh blank_linux
+    ./compile_program.sh blank_program.st
+    cp "start_openplc.sh" "$OPENPLC_DIR"
+) }
+
 if [ "$1" == "win" ]; then
     echo "Installing OpenPLC on Windows"
     cp ./utils/apt-cyg/apt-cyg ./
@@ -246,14 +254,7 @@ if [ "$1" == "win" ]; then
     cd "$OPENPLC_DIR"
 
     install_libmodbus
-
-    echo ""
-    echo "[FINALIZING]"
-    cd "$OPENPLC_DIR/webserver/scripts"
-    ./change_hardware_layer.sh blank
-    ./compile_program.sh blank_program.st
-    cp ./start_openplc.sh "$OPENPLC_DIR"
-
+    finalize_install
 
 elif [ "$1" == "linux" ]; then
 
@@ -292,12 +293,7 @@ elif [ "$1" == "linux" ]; then
         sudo cp /usr/local/lib/lib*.* /lib64/
     fi
     
-    echo ""
-    echo "[FINALIZING]"
-    cd "$OPENPLC_DIR/webserver/scripts"
-    ./change_hardware_layer.sh blank_linux
-    ./compile_program.sh blank_program.st
-    cp "start_openplc.sh" "$OPENPLC_DIR"
+    finalize_install
 
 
 elif [ "$1" == "docker" ]; then
@@ -305,13 +301,7 @@ elif [ "$1" == "docker" ]; then
     linux_install_deps
     install_py_deps
     install_all_libs
-
-    echo ""
-    echo "[FINALIZING]"
-    cd "$OPENPLC_DIR/webserver/scripts"
-    ./change_hardware_layer.sh blank_linux
-    ./compile_program.sh blank_program.st
-    cp ./start_openplc.sh "$OPENPLC_DIR"
+    finalize_install
 
 elif [ "$1" == "rpi" ]; then
     echo "Installing OpenPLC on Raspberry Pi"
@@ -323,15 +313,7 @@ elif [ "$1" == "rpi" ]; then
     install_py_deps "sudo -H" 
 
     install_all_libs sudo
-
-    echo ""
-    echo "[FINALIZING]"
-    cd "$OPENPLC_DIR/webserver/scripts"
-    ./change_hardware_layer.sh blank_linux
-    ./compile_program.sh blank_program.st
-    cp ./start_openplc.sh "$OPENPLC_DIR"
-
-
+    finalize_install
 
 elif [ "$1" == "neuron" ]; then
     echo "Installing OpenPLC on UniPi Neuron PLC"
@@ -351,28 +333,12 @@ elif [ "$1" == "neuron" ]; then
     install_py_deps "sudo -H"
 
     install_all_libs sudo
-
-    echo ""
-    echo "[FINALIZING]"
-    cd "$OPENPLC_DIR/webserver/scripts"
-    ./change_hardware_layer.sh blank_linux
-    ./compile_program.sh blank_program.st
-    cp ./start_openplc.sh "$OPENPLC_DIR"
-
-
+    finalize_install
 
 elif [ "$1" == "custom" ]; then
     echo "Installing OpenPLC on Custom Platform"
-
     install_all_libs
-
-    echo ""
-    echo "[FINALIZING]"
-    cd "$OPENPLC_DIR/webserver/scripts"
-    ./change_hardware_layer.sh blank_linux
-    ./compile_program.sh blank_program.st
-    cp ./start_openplc.sh "$OPENPLC_DIR"
-
+    finalize_install
 
 else
     echo ""

--- a/background_installer.sh
+++ b/background_installer.sh
@@ -35,7 +35,7 @@ function linux_install_deps {
         $1 apt-get update
         $1 apt-get install -y build-essential pkg-config bison flex autoconf \
                               automake libtool make git python2.7 \
-                              sqlite3 cmake git curl python3 python3-pip
+                              sqlite3 cmake git curl python3 python3-pip libmodbus-dev
     else
         echo "Unsupported linux distro."
         exit 1
@@ -144,6 +144,8 @@ function install_opendnp3 {
 }
 
 function install_libmodbus {
+    [ -r /usr/include/modbus/modbus.h ] && return 0
+
     echo "[LIBMODBUS]"
     cd "$OPENPLC_DIR/utils/libmodbus_src"
     ./autogen.sh

--- a/background_installer.sh
+++ b/background_installer.sh
@@ -77,7 +77,7 @@ function install_matiec { (
     fi
 ) }
 
-function install_st_libs { (
+function install_st_optimizer { (
     echo "[ST OPTIMIZER]"
     cd "$OPENPLC_DIR/utils/st_optimizer_src"
     g++ st_optimizer.cpp -o st_optimizer
@@ -177,7 +177,7 @@ WantedBy=multi-user.target" | $1 tee /lib/systemd/system/openplc.service > /dev/
 
 function install_all_libs {
     install_matiec "$1"
-    install_st_libs "$1"
+    install_st_optimizer "$1"
     install_glue_generator "$1"
     install_opendnp3 "$1"
     install_libmodbus "$1"
@@ -221,7 +221,7 @@ if [ "$1" == "win" ]; then
         exit 1
     fi
 
-    install_st_libs
+    install_st_optimizer
     install_glue_generator
 
     echo ""

--- a/background_installer.sh
+++ b/background_installer.sh
@@ -54,7 +54,12 @@ function install_py_deps {
 
 function swap_on { (
     echo "creating swapfile..."
+
+    # Fallocate is instantaneous. Only use dd as fallback.
+    $1 touch "$SWAP_FILE"
+    $1 fallocate -zl 1G "$SWAP_FILE" ||
     $1 dd if=/dev/zero of="$SWAP_FILE" bs=1M count=1000
+
     $1 mkswap "$SWAP_FILE"
     $1 swapon "$SWAP_FILE"
 ) }

--- a/background_installer.sh
+++ b/background_installer.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 OPENPLC_DIR="$PWD"
 SWAP_FILE="$OPENPLC_DIR/swapfile"
-ETHERCAT_INSTALL=""
 
 function print_help_and_exit {
     echo ""

--- a/background_installer.sh
+++ b/background_installer.sh
@@ -52,7 +52,7 @@ function install_py_deps {
     $1 pip3 install pymodbus==2.5.3
 }
 
-function swap_on { (
+function swap_on {
     echo "creating swapfile..."
 
     # Fallocate is instantaneous. Only use dd as fallback.
@@ -62,15 +62,15 @@ function swap_on { (
 
     $1 mkswap "$SWAP_FILE"
     $1 swapon "$SWAP_FILE"
-) }
+}
 
-function swap_off { (
+function swap_off {
     echo "removing swapfile..."
     $1 swapoff "$SWAP_FILE"
     $1 rm -f "$SWAP_FILE"
-) }
+}
 
-function install_matiec { (
+function install_matiec {
     echo "[MATIEC COMPILER]"
     cd "$OPENPLC_DIR/utils/matiec_src"
     autoreconf -i
@@ -82,9 +82,10 @@ function install_matiec { (
         echo "OpenPLC was NOT installed!"
         exit 1
     fi
-) }
+    cd "$OPENPLC_DIR"
+}
 
-function install_st_optimizer { (
+function install_st_optimizer {
     echo "[ST OPTIMIZER]"
     cd "$OPENPLC_DIR/utils/st_optimizer_src"
     g++ st_optimizer.cpp -o st_optimizer
@@ -94,9 +95,10 @@ function install_st_optimizer { (
         echo "OpenPLC was NOT installed!"
         exit 1
     fi
-) }
+    cd "$OPENPLC_DIR"
+}
 
-function install_glue_generator { (
+function install_glue_generator {
     echo "[GLUE GENERATOR]"
     cd "$OPENPLC_DIR/utils/glue_generator_src"
     g++ -std=c++11 glue_generator.cpp -o glue_generator
@@ -106,9 +108,10 @@ function install_glue_generator { (
         echo "OpenPLC was NOT installed!"
         exit 1
     fi
-) }
+    cd "$OPENPLC_DIR"
+}
 
-function install_ethercat { (
+function install_ethercat {
     if [ "$ETHERCAT_INSTALL" == "install" ]; then
         echo ""
         echo "[EtherCAT]"
@@ -120,9 +123,10 @@ function install_ethercat { (
             exit 1
         fi
     fi
-) }
+    cd "$OPENPLC_DIR"
+}
 
-function install_opendnp3 { (
+function install_opendnp3 {
     echo "[OPEN DNP3]"
     cd "$OPENPLC_DIR/utils/dnp3_src"
     swap_on
@@ -136,9 +140,10 @@ function install_opendnp3 { (
     fi
     $1 ldconfig
     swap_off
-) }
+    cd "$OPENPLC_DIR"
+}
 
-function install_libmodbus { (
+function install_libmodbus {
     echo "[LIBMODBUS]"
     cd "$OPENPLC_DIR/utils/libmodbus_src"
     ./autogen.sh
@@ -150,9 +155,10 @@ function install_libmodbus { (
         exit 1
     fi
     $1 ldconfig
-) }
+    cd "$OPENPLC_DIR"
+}
 
-function install_systemd_service() { (
+function install_systemd_service() {
     if [ "$1" == "sudo" ]; then
         echo "[OPENPLC SERVICE]"
         $1 tee /lib/systemd/system/openplc.service > /dev/null <<EOF
@@ -176,7 +182,7 @@ EOF
         $1 systemctl daemon-reload
         $1 systemctl enable openplc
     fi
-) }
+}
 
 function install_all_libs {
     install_matiec "$1"
@@ -186,13 +192,14 @@ function install_all_libs {
     install_libmodbus "$1"
 }
 
-function finalize_install { (
+function finalize_install {
     echo "[FINALIZING]"
     cd "$OPENPLC_DIR/webserver/scripts"
     ./change_hardware_layer.sh blank_linux
     ./compile_program.sh blank_program.st
     cp "start_openplc.sh" "$OPENPLC_DIR"
-) }
+    cd "$OPENPLC_DIR"
+}
 
 if [ "$1" == "win" ]; then
     echo "Installing OpenPLC on Windows"

--- a/background_installer.sh
+++ b/background_installer.sh
@@ -52,6 +52,19 @@ function install_py_deps {
     $1 pip3 install pymodbus==2.5.3
 }
 
+function swap_on { (
+    echo "creating swapfile..."
+    $1 dd if=/dev/zero of=swapfile bs=1M count=1000
+    $1 mkswap swapfile
+    $1 swapon swapfile
+) }
+
+function swap_off { (
+    echo "removing swapfile..."
+    $1 swapoff swapfile
+    $1 rm -f ./swapfile
+) }
+
 function install_matiec { (
     echo "[MATIEC COMPILER]"
     cd "$OPENPLC_DIR/utils/matiec_src"
@@ -107,10 +120,7 @@ function install_ethercat { (
 function install_opendnp3 { (
     echo "[OPEN DNP3]"
     cd "$OPENPLC_DIR/utils/dnp3_src"
-    echo "creating swapfile..."
-    $1 dd if=/dev/zero of=swapfile bs=1M count=1000
-    $1 mkswap swapfile
-    $1 swapon swapfile
+    swap_on
     cmake .
     make
     $1 make install
@@ -120,9 +130,7 @@ function install_opendnp3 { (
         exit 1
     fi
     $1 ldconfig
-    echo "removing swapfile..."
-    $1 swapoff swapfile
-    $1 rm -f ./swapfile
+    swap_off
 ) }
 
 function install_libmodbus { (

--- a/background_installer.sh
+++ b/background_installer.sh
@@ -25,31 +25,20 @@ fi
 #set -x 
 # arg1: sudo or blank
 function linux_install_deps {
-    #Detecting OS type
-    INSTALLER=""
-    OS=$(awk '/NAME=/' /etc/*-release | sed -n '1 p' | cut -d= -f2 | cut -d\" -f2 | cut -d" " -f1)
-
-    if [ "$OS" = "Fedora" ]; then
-        INSTALLER="yum"
-    elif [ "$OS" = "CentOS" ]; then
-        INSTALLER="yum"
-    elif [ "$OS" = "Red" ]; then
-        INSTALLER="yum"
-    else
-        INSTALLER="apt"
-    fi
-    
-    if [ "$INSTALLER" = "yum" ]; then
+    if [ -x /bin/yum ]; then
         yum clean expire-cache
         yum check-update
         $1 yum -q -y install curl make automake gcc gcc-c++ kernel-devel pkg-config bison flex autoconf libtool openssl-devel cmake python3 python3-pip
         $1 yum -q -y install python2.7 python2-devel
     #Installing dependencies for Ubuntu/Mint/Debian
-    else
+    elif [ -x /bin/apt-get ]; then
         $1 apt-get update
         $1 apt-get install -y build-essential pkg-config bison flex autoconf \
                               automake libtool make git python2.7 \
                               sqlite3 cmake git curl python3 python3-pip
+    else
+        echo "Unsupported linux distro."
+        exit 1
     fi
     curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
     $1 python2.7 get-pip.py
@@ -273,22 +262,8 @@ elif [ "$1" == "linux" ]; then
     install_all_libs sudo
     install_systemd_service sudo
 
-    #Detecting OS type
-    OS_TYPE=""
-    OS=$(awk '/NAME=/' /etc/*-release | sed -n '1 p' | cut -d= -f2 | cut -d\" -f2 | cut -d" " -f1)
-
-    if [ "$OS" = "Fedora" ]; then
-        OS_TYPE="yum"
-    elif [ "$OS" = "CentOS" ]; then
-        OS_TYPE="yum"
-    elif [ "$OS" = "Red" ]; then
-        OS_TYPE="yum"
-    else
-        OS_TYPE="apt"
-    fi
-    
-    #Fix for Fedora
-    if [ "$OS_TYPE" = "yum" ]; then
+    # Fix for RPM-based distros
+    if [ -x /bin/yum ]; then
         sudo cp /usr/local/lib/pkgconfig/libmodbus.pc /usr/share/pkgconfig/
         sudo cp /usr/local/lib/lib*.* /lib64/
     fi

--- a/background_installer.sh
+++ b/background_installer.sh
@@ -123,6 +123,19 @@ function install_opendnp3 {
     cd "$OPENPLC_DIR"
 }
 
+function disable_opendnp3 {
+    echo ""
+    echo "[OPEN DNP3]"
+    cd "$OPENPLC_DIR/webserver/core"
+    if test -f dnp3.cpp; then
+        mv dnp3.cpp dnp3.disabled || fail "Error disabling OpenDNP3"
+    fi
+    if test -f dnp3_dummy.disabled; then
+        mv dnp3_dummy.disabled dnp3_dummy.cpp || fail "Error disabling OpenDNP3"
+    fi
+    cd "$OPENPLC_DIR"
+}
+
 function install_libmodbus {
     [ -r /usr/include/modbus/modbus.h ] && return 0
 
@@ -223,18 +236,7 @@ if [ "$1" == "win" ]; then
 
     install_st_optimizer
     install_glue_generator
-
-    echo ""
-    echo "[OPEN DNP3]"
-    cd "$OPENPLC_DIR/webserver/core"
-    if test -f dnp3.cpp; then
-        mv dnp3.cpp dnp3.disabled || fail "Error disabling OpenDNP3"
-    fi
-    if test -f dnp3_dummy.disabled; then
-        mv dnp3_dummy.disabled dnp3_dummy.cpp || fail "Error disabling OpenDNP3"
-    fi
-    cd "$OPENPLC_DIR"
-
+    disable_opendnp3
     install_libmodbus
     finalize_install
 


### PR DESCRIPTION
This is a reasonably large set of changes, but I broke it up in several small pieces in order to make each step readable.

Changes and improvements:
- Multiple refactoring and de-duplication of code.
- Prefer distribution supplied libmodbus when available.
- Instant swap creation via fallocate (rpi).
- Avoid systemd service files on docker.
- Fix runtime compile warning when EtherCAT was not instaled (rpi, windows, custom).

Tested build, run, launch blank (compile runtime), start and stop on docker/debian:10, docker/fedora:latest, docker/ubuntu:latest.

Untested windows, raspberry pi and EtherCAT.