### PR TITLE
reduction in compiler warnings

### DIFF
--- a/webserver/core/client.cpp
+++ b/webserver/core/client.cpp
@@ -41,7 +41,7 @@
 int connect_to_tcp_server(uint8_t *ip_address, uint16_t port, int method)
 {
     int sockfd, connfd;
-    unsigned char log_msg[1000];
+    char log_msg[1000];
     struct sockaddr_in servaddr, cli;
     
     if (method == METHOD_TCP)
@@ -93,7 +93,7 @@ int connect_to_tcp_server(uint8_t *ip_address, uint16_t port, int method)
 int send_tcp_message(uint8_t *msg, size_t msg_size, int socket_id)
 {
     int bytes_sent = 0;
-    unsigned char log_msg[1000];
+    char log_msg[1000];
     bytes_sent = write(socket_id, msg, msg_size);
     if (bytes_sent < 0)
     {
@@ -108,7 +108,7 @@ int send_tcp_message(uint8_t *msg, size_t msg_size, int socket_id)
 int receive_tcp_message(uint8_t *msg_buffer, size_t buffer_size, int socket_id)
 {
     int bytes_received = 0;
-    unsigned char log_msg[1000];
+    char log_msg[1000];
     bytes_received = read(socket_id, msg_buffer, buffer_size);
     
     if (bytes_received < 0 && bytes_received != EAGAIN && bytes_received != EWOULDBLOCK)

--- a/webserver/core/dnp3.cpp
+++ b/webserver/core/dnp3.cpp
@@ -410,7 +410,7 @@ OutstationStackConfig parseDNP3Config() {
 
 void ConsoleLogger::Log(const openpal::LogEntry& entry)
 {
-    unsigned char log_msg[1000];
+    char log_msg[1000];
     sprintf(log_msg, "DNP3 ID %s: %s\n", entry.loggerid, entry.message);
     log(log_msg);
 }

--- a/webserver/core/enip.cpp
+++ b/webserver/core/enip.cpp
@@ -513,8 +513,8 @@ int sendUnitData(struct enip_header *header, struct enip_data_Connected_0x70 *en
 int processEnipMessage(unsigned char *buffer, int buffer_size)
 {	
 	// initialize logging system
-	unsigned char log_msg[1000];
-    unsigned char *p = log_msg;
+	char log_msg[1000];
+    char *p = log_msg;
 	
 	// initailize structs
     struct enip_header header;

--- a/webserver/core/hardware_layers/neuron.cpp
+++ b/webserver/core/hardware_layers/neuron.cpp
@@ -98,7 +98,7 @@ void searchForIO()
 {
     char path[200];
     char path_fmt[200];
-    unsigned char log_msg[1000];
+    char log_msg[1000];
     
     sprintf(log_msg, "Neuron: Searching for I/O...\n");
     log(log_msg);

--- a/webserver/core/hardware_layers/psm.cpp
+++ b/webserver/core/hardware_layers/psm.cpp
@@ -59,7 +59,7 @@ void check_error_count()
 {
     if (error_count >= ERROR_LIMIT)
     {
-        unsigned char log_msg[1000];
+        char log_msg[1000];
         sprintf(log_msg, "PSM: Too many errors!\nPSM: PSM is disabled\n");
         log(log_msg);
     }
@@ -102,7 +102,7 @@ void *start_psm()
 //-----------------------------------------------------------------------------
 int connect_to_psm(int debug)
 {
-    unsigned char log_msg[1000];
+    char log_msg[1000];
     int sock = 0;
     struct sockaddr_in serv_addr;
 
@@ -147,7 +147,7 @@ int connect_to_psm(int debug)
 //-----------------------------------------------------------------------------
 void read_ana_inp(int psm)
 {
-    unsigned char log_msg[1000];
+    char log_msg[1000];
     //                          tid     pid     len   uid  fc  start   count
     unsigned char request[] = {00, 01, 00, 00, 00, 06, 00, 04, 00, 00, 00, 25};
     unsigned char buffer[1024];
@@ -196,7 +196,7 @@ void read_ana_inp(int psm)
 //-----------------------------------------------------------------------------
 void write_ana_out(int psm)
 {
-    unsigned char log_msg[1000];
+    char log_msg[1000];
     //                           tid     pid     len  uid  fc  start   count  len
     unsigned char request[] = {00, 01, 00, 00, 00, 57, 00, 16, 00, 00, 00, 25, 50, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00};
     unsigned char buffer[1024];
@@ -261,7 +261,7 @@ void write_ana_out(int psm)
 //-----------------------------------------------------------------------------
 void read_dig_inp(int psm)
 {
-    unsigned char log_msg[1000];
+    char log_msg[1000];
     //                          tid     pid     len   uid  fc  start   count
     unsigned char request[] = {00, 01, 00, 00, 00, 06, 00, 02, 00, 00, 0x01, 0x90}; //reading 400 coils count = 0x0190
     unsigned char buffer[1024];
@@ -302,7 +302,7 @@ void read_dig_inp(int psm)
 //-----------------------------------------------------------------------------
 void write_dig_out(int psm)
 {
-    unsigned char log_msg[1000];
+    char log_msg[1000];
     //                          tid     pid     len   uid  fc  start   count (400 coils - 50 bytes)
     unsigned char request[] = {00, 01, 00, 00, 00, 57, 00, 15, 00, 00, 0x01, 0x90, 50, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00};
     unsigned char buffer[1024];
@@ -339,7 +339,7 @@ void write_dig_out(int psm)
 //-----------------------------------------------------------------------------
 void stop_psm(int psm)
 {
-    unsigned char log_msg[1000];
+    char log_msg[1000];
     //                          tid     pid     len   uid  fc  address value
     unsigned char request[] = {00, 01, 00, 00, 00, 06, 00, 06, 00, 50, 00, 127};
     unsigned char buffer[1024];
@@ -435,7 +435,7 @@ void initializeHardware()
     }
     sleepms(2000);
     
-    unsigned char log_msg[1000];
+    char log_msg[1000];
     psm = connect_to_psm(1);
     if (psm < 0)
     {

--- a/webserver/core/hardware_layers/sequent.cpp
+++ b/webserver/core/hardware_layers/sequent.cpp
@@ -82,7 +82,7 @@
 
 int log_error(int line)
 {
-	unsigned char log_msg[1000];
+	char log_msg[1000];
 
 #ifdef GEN_DEBUG
 	sprintf(log_msg, "!line %d\n", line);
@@ -95,6 +95,7 @@ int i2cSetup(int addr)
 {
 	static int file = -1;
 	char filename[32];
+	char log_msg[1000];
 
 	if (file < 0)
 	{
@@ -102,14 +103,16 @@ int i2cSetup(int addr)
 
 		if ( (file = open(filename, O_RDWR)) < 0)
 		{
-			log("Failed to open the bus.\n");
+			sprintf(log_msg, "Failed to open the bus.\n");
+			log(log_msg);
 
 			return ERROR;
 		}
 	}
 	if (ioctl(file, I2C_SLAVE, addr) < 0)
 	{
-		log("Failed to acquire bus access and/or talk to slave.\n");
+		sprintf(log_msg, "Failed to acquire bus access and/or talk to slave.\n");
+		log(log_msg);
 		return ERROR;
 	}
 	return file;
@@ -154,7 +157,7 @@ int i2cMemRead(int dev, int add, uint8_t *buff, int size)
 int i2cMemWrite(int dev, int add, uint8_t *buff, int size)
 {
 	uint8_t intBuff[I2C_SMBUS_BLOCK_MAX];
-	unsigned char log_msg[1000];
+	char log_msg[1000];
 
 	if (NULL == buff)
 	{

--- a/webserver/core/interactive_server.cpp
+++ b/webserver/core/interactive_server.cpp
@@ -149,7 +149,7 @@ unsigned char *readCommandArgumentStr(unsigned char *command)
 //-----------------------------------------------------------------------------
 int createSocket_interactive(int port)
 {
-    unsigned char log_msg[1000];
+    char log_msg[1000];
     int socket_fd;
     struct sockaddr_in server_addr;
 
@@ -234,7 +234,7 @@ int listenToClient_interactive(int client_fd, unsigned char *buffer)
 //-----------------------------------------------------------------------------
 void processCommand(unsigned char *buffer, int client_fd)
 {
-    unsigned char log_msg[1000];
+    char log_msg[1000];
     int count_char = 0;
     
     if (processing_command)
@@ -508,7 +508,7 @@ void *handleConnections_interactive(void *arguments)
 //-----------------------------------------------------------------------------
 void startInteractiveServer(int port)
 {
-    unsigned char log_msg[1000];
+    char log_msg[1000];
     int socket_fd, client_fd;
     socket_fd = createSocket_interactive(port);
 

--- a/webserver/core/ladder.h
+++ b/webserver/core/ladder.h
@@ -121,7 +121,7 @@ extern int ignored_int_outputs[];
 //main.cpp
 void sleep_until(struct timespec *ts, long long delay);
 void sleepms(int milliseconds);
-void log(unsigned char *logmsg);
+void log(char *logmsg);
 bool pinNotPresent(int *ignored_vector, int vector_size, int pinNumber);
 extern uint8_t run_openplc;
 extern unsigned char log_buffer[1000000];

--- a/webserver/core/main.cpp
+++ b/webserver/core/main.cpp
@@ -99,13 +99,13 @@ static inline void timespec_diff(struct timespec *a, struct timespec *b, struct 
 //-----------------------------------------------------------------------------
 // Helper function - Logs messages and print them on the console
 //-----------------------------------------------------------------------------
-void log(unsigned char *logmsg)
+void log(char *logmsg)
 {
     pthread_mutex_lock(&logLock); //lock mutex
     printf("%s", logmsg);
     for (int i = 0; logmsg[i] != '\0'; i++)
     {
-        log_buffer[log_index] = logmsg[i];
+        log_buffer[log_index] = (unsigned char)logmsg[i];
         log_index++;
         log_buffer[log_index] = '\0';
     }
@@ -220,7 +220,7 @@ u_int32_t *dint_input_call_back(int a){ return dint_input[a]; }
 u_int32_t *dint_output_call_back(int a){ return dint_output[a]; }
 u_int64_t *lint_input_call_back(int a){ return lint_input[a]; }
 u_int64_t *lint_output_call_back(int a){ return lint_output[a]; }
-void logger_callback(unsigned char *msg){ log(msg);}
+void logger_callback(char *msg){ log(msg);}
 
 int main(int argc,char **argv)
 {
@@ -234,8 +234,8 @@ int main(int argc,char **argv)
     latency_min = LONG_MAX;
     latency_total = 0;
 
-    unsigned char log_msg[1000];
-    sprintf((char *)log_msg, "OpenPLC Runtime starting...\n");
+    char log_msg[1000];
+    sprintf(log_msg, "OpenPLC Runtime starting...\n");
     log(log_msg);
 
     //======================================================

--- a/webserver/core/modbus_master.cpp
+++ b/webserver/core/modbus_master.cpp
@@ -315,7 +315,7 @@ void parseConfig()
     }
     else
     {
-        unsigned char log_msg[1000];
+        char log_msg[1000];
         sprintf(log_msg, "Skipping configuration of Slave Devices (mbconfig.cfg file not found)\n");
         log(log_msg);
     }
@@ -354,7 +354,7 @@ void *querySlaveDevices(void *arg)
 {
     while (run_openplc)
     {
-        unsigned char log_msg[1000];
+        char log_msg[1000];
         
         uint16_t bool_input_index = 0;
         uint16_t bool_output_index = 0;
@@ -637,7 +637,7 @@ void initializeMB()
                 if (mb_devices[i].rtu_baud != mb_devices[share_index].rtu_baud || mb_devices[i].rtu_parity != mb_devices[share_index].rtu_parity || 
                     mb_devices[i].rtu_data_bit != mb_devices[share_index].rtu_data_bit || mb_devices[i].rtu_stop_bit != mb_devices[share_index].rtu_stop_bit)
                 {
-                    unsigned char log_msg[1000];
+                    char log_msg[1000];
                     sprintf(log_msg, "Warning MB device %s port setting missmatch\n", mb_devices[i].dev_name);
                     log(log_msg);
                 }

--- a/webserver/core/pccc.cpp
+++ b/webserver/core/pccc.cpp
@@ -173,8 +173,7 @@ uint16_t Command_Protocol(pccc_header header, unsigned char *buffer, int buffer_
 	else
 	{
 		/*initialize logging system*/
-		unsigned char log_msg[1000];
-		unsigned char *p = log_msg;
+		char log_msg[1000];
 		sprintf(log_msg, "PCCC: Unsupportedd Command/Data Function Code!\n");
 		log(log_msg); 
 		return -1;
@@ -216,8 +215,7 @@ uint16_t Protected_Logical_Read_Reply(pccc_header header, unsigned char *buffer,
 	}
 	else
 	{
-		unsigned char log_msg[1000];
-		unsigned char *p = log_msg;
+		char log_msg[1000];
 		sprintf(log_msg, "PCCC: Error occured while processing Protected Logical Read\n");
 		log(log_msg); 
 		return -1;

--- a/webserver/core/persistent_storage.cpp
+++ b/webserver/core/persistent_storage.cpp
@@ -40,7 +40,7 @@ void startPstorage()
     while (pstorage_read == false)
         sleepms(100);
     
-    unsigned char log_msg[1000];
+    char log_msg[1000];
     IEC_UINT persistentBuffer[BUFFER_SIZE];
 
     //Read initial buffers into persistent struct
@@ -126,7 +126,7 @@ void startPstorage()
 //-----------------------------------------------------------------------------
 int readPersistentStorage()
 {
-    unsigned char log_msg[1000];
+    char log_msg[1000];
     FILE *fd = fopen("persistent.file", "r");
     if (fd == NULL)
     {

--- a/webserver/core/server.cpp
+++ b/webserver/core/server.cpp
@@ -86,7 +86,7 @@ bool SetSocketBlockingEnabled(int fd, bool blocking)
 //-----------------------------------------------------------------------------
 int createSocket(uint16_t port)
 {
-    unsigned char log_msg[1000];
+    char log_msg[1000];
     int socket_fd;
     struct sockaddr_in server_addr;
 
@@ -134,7 +134,7 @@ int createSocket(uint16_t port)
 //-----------------------------------------------------------------------------
 int waitForClient(int socket_fd, int protocol_type)
 {
-    unsigned char log_msg[1000];
+    char log_msg[1000];
     int client_fd;
     struct sockaddr_in client_addr;
     bool *run_server;
@@ -197,7 +197,7 @@ void processMessage(unsigned char *buffer, int bufferSize, int client_fd, int pr
 //-----------------------------------------------------------------------------
 void *handleConnections(void *arguments)
 {
-    unsigned char log_msg[1000];
+    char log_msg[1000];
     int *args = (int *)arguments;
     int client_fd = args[0];
     int protocol_type = args[1];
@@ -251,7 +251,7 @@ void *handleConnections(void *arguments)
 //-----------------------------------------------------------------------------
 void startServer(uint16_t port, int protocol_type)
 {
-    unsigned char log_msg[1000];
+    char log_msg[1000];
     int socket_fd, client_fd;
     bool *run_server;
     


### PR DESCRIPTION
in main.cpp log() function is responsible for most compiler warnings that are ignored with -w flag

changed it from void log(unsigned char *logmsg) to void log(char *logmsg)

normally in c strings are arrays of char, not of unsigned char, -fpermissive and -w hides the issue, but this wall of warnings is problematic when trying to make sure nothing else is wrong.

this one change reduced warnings from 125 to 56

