### PR TITLE
fix pwm range from 255 to 1024

### DIFF
--- a/webserver/core/hardware_layers/raspberrypi.cpp
+++ b/webserver/core/hardware_layers/raspberrypi.cpp
@@ -93,8 +93,10 @@ void initializeHardware()
 	//set PWM pins as output
 	for (int i = 0; i < MAX_ANALOG_OUT; i++)
 	{
-	    if (pinNotPresent(ignored_int_outputs, ARRAY_SIZE(ignored_int_outputs), analogOutBufferPinMask[i]))
+	    if (pinNotPresent(ignored_int_outputs, ARRAY_SIZE(ignored_int_outputs), analogOutBufferPinMask[i])) {
     		gpioSetMode(analogOutBufferPinMask[i], PI_ALT5);
+		gpioSetPWMrange(analogOutBufferPinMask[i], 1024);
+	    }
 	}
 }
 


### PR DESCRIPTION
The previous library's, wiringpi, default PWM range is 0-1024. The code currently scales down the 16bit value held in memory to this range. pigpio's default is 0-255, so the taken option was to set this attribute manually to the previous range.