### PR TITLE
active_program should be part of persistent storage in dockers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,19 @@ VOLUME /persistent
 RUN ./install.sh docker
 RUN touch /persistent/mbconfig.cfg
 RUN touch /persistent/persistent.file
+RUN touch /persistent/active_program
 RUN mkdir /persistent/st_files
 RUN cp /workdir/webserver/openplc.db /persistent/openplc.db
 RUN mv /workdir/webserver/openplc.db /workdir/webserver/openplc_default.db
 RUN cp /workdir/webserver/dnp3.cfg /persistent/dnp3.cfg
 RUN mv /workdir/webserver/dnp3.cfg /workdir/webserver/dnp3_default.cfg
 RUN cp /workdir/webserver/st_files/* /persistent/st_files
-run mv /workdir/webserver/st_files /workdir/webserver/st_files_default
+RUN mv /workdir/webserver/st_files /workdir/webserver/st_files_default
 RUN ln -s /persistent/mbconfig.cfg /workdir/webserver/mbconfig.cfg
 RUN ln -s /persistent/persistent.file /workdir/webserver/persistent.file
 RUN ln -s /persistent/openplc.db /workdir/webserver/openplc.db
 RUN ln -s /persistent/dnp3.cfg /workdir/webserver/dnp3.cfg
 RUN ln -s /persistent/st_files /workdir/webserver/st_files
+RUN ln -s /persistent/active_program /workdir/webserver/active_program
 
 ENTRYPOINT ["./start_openplc.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ VOLUME /persistent
 RUN ./install.sh docker
 RUN touch /persistent/mbconfig.cfg
 RUN touch /persistent/persistent.file
-RUN touch /persistent/active_program
 RUN mkdir /persistent/st_files
 RUN cp /workdir/webserver/openplc.db /persistent/openplc.db
 RUN mv /workdir/webserver/openplc.db /workdir/webserver/openplc_default.db
@@ -14,6 +13,8 @@ RUN cp /workdir/webserver/dnp3.cfg /persistent/dnp3.cfg
 RUN mv /workdir/webserver/dnp3.cfg /workdir/webserver/dnp3_default.cfg
 RUN cp /workdir/webserver/st_files/* /persistent/st_files
 RUN mv /workdir/webserver/st_files /workdir/webserver/st_files_default
+RUN cp /workdir/webserver/active_program /persistent/active_program
+RUN mv /workdir/webserver/active_program /workdir/webserver/active_program_default
 RUN ln -s /persistent/mbconfig.cfg /workdir/webserver/mbconfig.cfg
 RUN ln -s /persistent/persistent.file /workdir/webserver/persistent.file
 RUN ln -s /persistent/openplc.db /workdir/webserver/openplc.db


### PR DESCRIPTION
The "active_program" file should be part of persistent storage in dockers.
If not, when restarting the docker after changing the name of the running program, the runtime will fail to find the matching entry in openplc.db.