### PR TITLE
Fix issues with Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-20211201
+FROM debian:bullseye-20240722
 COPY . /workdir
 WORKDIR /workdir
 RUN mkdir /persistent

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN cp /workdir/webserver/openplc.db /persistent/openplc.db
 RUN mv /workdir/webserver/openplc.db /workdir/webserver/openplc_default.db
 RUN cp /workdir/webserver/dnp3.cfg /persistent/dnp3.cfg
 RUN mv /workdir/webserver/dnp3.cfg /workdir/webserver/dnp3_default.cfg
-RUN cp /workdir/webserver/st_files/* /persistent/st_files
+RUN cp -r /workdir/webserver/st_files/ /persistent/st_files/
 RUN mv /workdir/webserver/st_files /workdir/webserver/st_files_default
 RUN cp /workdir/webserver/active_program /persistent/active_program
 RUN mv /workdir/webserver/active_program /workdir/webserver/active_program_default

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,30 @@
 FROM debian:bullseye-20240722
+
 COPY . /workdir
+
 WORKDIR /workdir
+
 RUN mkdir /persistent
+
 VOLUME /persistent
-RUN ./install.sh docker
-RUN touch /persistent/mbconfig.cfg
-RUN touch /persistent/persistent.file
-RUN mkdir /persistent/st_files
-RUN cp /workdir/webserver/openplc.db /persistent/openplc.db
-RUN mv /workdir/webserver/openplc.db /workdir/webserver/openplc_default.db
-RUN cp /workdir/webserver/dnp3.cfg /persistent/dnp3.cfg
-RUN mv /workdir/webserver/dnp3.cfg /workdir/webserver/dnp3_default.cfg
-RUN cp -r /workdir/webserver/st_files/ /persistent/st_files/
-RUN mv /workdir/webserver/st_files /workdir/webserver/st_files_default
-RUN cp /workdir/webserver/active_program /persistent/active_program
-RUN mv /workdir/webserver/active_program /workdir/webserver/active_program_default
-RUN ln -s /persistent/mbconfig.cfg /workdir/webserver/mbconfig.cfg
-RUN ln -s /persistent/persistent.file /workdir/webserver/persistent.file
-RUN ln -s /persistent/openplc.db /workdir/webserver/openplc.db
-RUN ln -s /persistent/dnp3.cfg /workdir/webserver/dnp3.cfg
-RUN ln -s /persistent/st_files /workdir/webserver/st_files
-RUN ln -s /persistent/active_program /workdir/webserver/active_program
+
+RUN ./install.sh docker \
+    && touch /persistent/mbconfig.cfg \
+    && touch /persistent/persistent.file \
+    && mkdir /persistent/st_files \
+    && cp /workdir/webserver/openplc.db /persistent/openplc.db \
+    && mv /workdir/webserver/openplc.db /workdir/webserver/openplc_default.db \
+    && cp /workdir/webserver/dnp3.cfg /persistent/dnp3.cfg \
+    && mv /workdir/webserver/dnp3.cfg /workdir/webserver/dnp3_default.cfg \
+    && cp -r /workdir/webserver/st_files/ /persistent/st_files/ \
+    && mv /workdir/webserver/st_files /workdir/webserver/st_files_default \
+    && cp /workdir/webserver/active_program /persistent/active_program \
+    && mv /workdir/webserver/active_program /workdir/webserver/active_program_default \
+    && ln -s /persistent/mbconfig.cfg /workdir/webserver/mbconfig.cfg \
+    && ln -s /persistent/persistent.file /workdir/webserver/persistent.file \
+    && ln -s /persistent/openplc.db /workdir/webserver/openplc.db \
+    && ln -s /persistent/dnp3.cfg /workdir/webserver/dnp3.cfg \
+    && ln -s /persistent/st_files /workdir/webserver/st_files \
+    && ln -s /persistent/active_program /workdir/webserver/active_program
 
 ENTRYPOINT ["./start_openplc.sh"]


### PR DESCRIPTION
While attempting to run `docker build -t openplc:v3 .` as mentioned in the `README.md` I encountered the following error:

```bash
docker build -t openplc:v3 .
...
...
STEP 14/24: RUN cp /workdir/webserver/st_files/* /persistent/st_files
cp: target '/persistent/st_files' is not a directory
Error: building at STEP "RUN cp /workdir/webserver/st_files/* /persistent/st_files": while running runtime: exit status 1
```

The first commit in this pull request resolves that issue.

I then noticed that the base image in use was significantly out of date so I bumped that to the latest available which significantly improves vulnerability status for the image:

**Before**
![Screenshot from 2024-07-24 10-40-15](https://github.com/user-attachments/assets/4b25b267-2e33-483e-bfea-edd182b9ee0a)


**After**
![Screenshot from 2024-07-24 10-40-36](https://github.com/user-attachments/assets/a11690d0-1a71-4950-bc5f-0386e3d27dbe)


I also refactored the `RUN` commands to complete this all as one layer which is a Docker best practice.