### PR TITLE
Fix handling write requests of 64 bit values from modbus

### DIFF
--- a/webserver/core/modbus.cpp
+++ b/webserver/core/modbus.cpp
@@ -812,17 +812,17 @@ void WriteMultipleRegisters(unsigned char *buffer, int bufferSize)
 					*lint_memory[(position - MIN_64B_RANGE) / 4] = *lint_memory[(position - MIN_64B_RANGE) / 4] & 0x0000ffffffffffff;
 					*lint_memory[(position - MIN_64B_RANGE) / 4] = *lint_memory[(position - MIN_64B_RANGE) / 4] | (tempValue << 48);
 				}
-				else if ((Start - MIN_64B_RANGE) % 4 == 1) //second word
+				else if ((position - MIN_64B_RANGE) % 4 == 1) //second word
 				{
 					*lint_memory[(position - MIN_64B_RANGE) / 4] = *lint_memory[(position - MIN_64B_RANGE) / 4] & 0xffff0000ffffffff;
 					*lint_memory[(position - MIN_64B_RANGE) / 4] = *lint_memory[(position - MIN_64B_RANGE) / 4] | (tempValue << 32);
 				}
-				else if ((Start - MIN_64B_RANGE) % 4 == 2) //third word
+				else if ((position - MIN_64B_RANGE) % 4 == 2) //third word
 				{
 					*lint_memory[(position - MIN_64B_RANGE) / 4] = *lint_memory[(position - MIN_64B_RANGE) / 4] & 0xffffffff0000ffff;
 					*lint_memory[(position - MIN_64B_RANGE) / 4] = *lint_memory[(position - MIN_64B_RANGE) / 4] | (tempValue << 16);
 				}
-				else if ((Start - MIN_64B_RANGE) % 4 == 3) //fourth word
+				else if ((position - MIN_64B_RANGE) % 4 == 3) //fourth word
 				{
 					*lint_memory[(position - MIN_64B_RANGE) / 4] = *lint_memory[(position - MIN_64B_RANGE) / 4] & 0xffffffffffff0000;
 					*lint_memory[(position - MIN_64B_RANGE) / 4] = *lint_memory[(position - MIN_64B_RANGE) / 4] | tempValue;
@@ -830,7 +830,7 @@ void WriteMultipleRegisters(unsigned char *buffer, int bufferSize)
 			}
 			else
 			{
-				mb_holding_regs[Start] = word(buffer[10],buffer[11]);
+				mb_holding_regs[position] = word(buffer[10],buffer[11]);
 			}
 		}
 		else //invalid address


### PR DESCRIPTION
Hello, thank you for this awesome project!

I was trying to write an `Int64` value via modbus and noticed that only the first byte seems to be written to memory. After digging around in the source code, I discovered that there is a copy-paste error (from `WriteRegister` to `WriteMultipleRegisters`). This PR fixes that copy paste error.

I've run an OpenPLC runtime instance with these changes and can confirm that I am able to correctly write an `Int64` value via modbus.

I want to keep the diff easy and simple for you to see the error, but I think the better solution rather than just fixing the copy-paste error would be to extract the common code between `WriteRegister` and `WriteMultipleRegisters`, so that bugs like these are less likely to happen. Should I do that?