### PR TITLE
Fix error handling in WriteMultipleRegisters

### DIFF
--- a/webserver/core/modbus.cpp
+++ b/webserver/core/modbus.cpp
@@ -755,7 +755,11 @@ void WriteMultipleRegisters(unsigned char *buffer, int bufferSize)
 	for(int i = 0; i < WordDataLength; i++)
 	{
 		int position = Start + i;
-		mb_error = writeToRegisterWithoutLocking(position, word(buffer[13 + i * 2], buffer[14 + i * 2]));
+		int error = writeToRegisterWithoutLocking(position, word(buffer[13 + i * 2], buffer[14 + i * 2]));
+		if (error != ERR_NONE)
+		{
+			mb_error = error;
+		}
 	}
 	pthread_mutex_unlock(&bufferLock);
 


### PR DESCRIPTION
Sorry, I just realized that I unintentionally introduced a change in #251.

Previously if the position of any of the values in the loop was invalid, we would set `mb_error`. But now we are overwriting `mb_error` every iteration of the loop, so if the first position is invalid and the second position is valid, `mb_error` will be `ERR_NONE` in the end.

This fixes my mistake, sorry about that.