### PR TITLE
Orange pi support

### DIFF
--- a/background_installer.sh
+++ b/background_installer.sh
@@ -13,6 +13,7 @@ function print_help_and_exit {
     echo "  linux         Install OpenPLC on a Debian-based Linux distribution"
     echo "  docker        Install OpenPLC in a Docker container"
     echo "  rpi           Install OpenPLC on a Raspberry Pi"
+    echo "  opi           Install OpenPLC on a Orange Pi"
     echo "  neuron        Install OpenPLC on a UniPi Neuron PLC"
     echo "  unipi         Install OpenPLC on a Raspberry Pi with UniPi v1.1 PLC"
     echo "  custom        Skip all specific package installation and tries to install"
@@ -87,6 +88,21 @@ function install_pigpio {
         make
         sudo make install
         rm -f master.zip
+    )
+}
+
+function install_wiringop {
+    echo "[WIRINGOP]"
+    local URL="https://github.com/orangepi-xunlong/wiringOP/archive/master.zip"
+    (
+        set -e
+        rm -f master.zip
+        wget -c "$URL"
+        unzip -o master.zip
+        cd wiringOP-master
+        sudo ./build clean
+        sudo ./build
+        rm -f ../master.zip
     )
 }
 
@@ -342,6 +358,15 @@ elif [ "$1" == "rpi" ]; then
     echo "Installing OpenPLC on Raspberry Pi"
     linux_install_deps sudo
     install_pigpio
+    install_py_deps
+    install_all_libs sudo
+    install_systemd_service sudo
+    finalize_install linux
+
+elif [ "$1" == "opi" ]; then
+    echo "Installing OpenPLC on Orange Pi"
+    linux_install_deps sudo
+    install_wiringop
     install_py_deps
     install_all_libs sudo
     install_systemd_service sudo

--- a/webserver/core/hardware_layers/opi_zero2.cpp
+++ b/webserver/core/hardware_layers/opi_zero2.cpp
@@ -1,0 +1,151 @@
+//-----------------------------------------------------------------------------
+// Copyright 2015 Thiago Alves
+//
+// Based on the LDmicro software by Jonathan Westhues
+// This file is part of the OpenPLC Software Stack.
+//
+// OpenPLC is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// OpenPLC is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with OpenPLC.  If not, see <http://www.gnu.org/licenses/>.
+//------
+//
+// This file is the hardware layer for the OpenPLC. If you change the platform
+// where it is running, you may only need to change this file. All the I/O
+// related stuff is here. Basically it provides functions to read and write
+// to the OpenPLC internal buffers in order to update I/O state.
+// Thiago Alves, Dec 2015
+//-----------------------------------------------------------------------------
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <wiringPi.h>
+#include <pthread.h>
+
+#include "ladder.h"
+#include "custom_layer.h"
+
+#if !defined(ARRAY_SIZE)
+    #define ARRAY_SIZE(x) (sizeof((x)) / sizeof((x)[0]))
+#endif
+
+#define MAX_INPUT 		4
+#define MAX_OUTPUT 		5
+#define MAX_ANALOG_OUT	2
+
+/********************I/O PINS CONFIGURATION*********************
+ * A good source for Orange Pi I/O pins information is:
+ * https://github.com/orangepi-xunlong/wiringOP
+ *
+ * The buffers below works as an internal mask, so that the
+ * OpenPLC can access each pin sequentially
+****************************************************************/
+//inBufferPinMask: pin mask for each input, which
+//means what pin is mapped to that OpenPLC input
+int inBufferPinMask[MAX_INPUT] = { 2, 5, 7, 8 };
+
+//outBufferPinMask: pin mask for each output, which
+//means what pin is mapped to that OpenPLC output
+int outBufferPinMask[MAX_OUTPUT] = { 6, 9, 10, 13, 16 };
+
+//analogOutBufferPinMask: pin mask for the analog PWM
+//output of the RaspberryPi
+int analogOutBufferPinMask[MAX_ANALOG_OUT] = { 3, 4 };
+
+//-----------------------------------------------------------------------------
+// This function is called by the main OpenPLC routine when it is initializing.
+// Hardware initialization procedures should be here.
+//-----------------------------------------------------------------------------
+void initializeHardware()
+{
+	// Init
+	wiringPiSetup();
+
+	//set pins as input
+	for (int i = 0; i < MAX_INPUT; i++)
+	{
+	    if (pinNotPresent(ignored_bool_inputs, ARRAY_SIZE(ignored_bool_inputs), i))
+	    {
+		    pinMode(inBufferPinMask[i], INPUT);
+	    }
+	}
+
+	//set pins as output
+	for (int i = 0; i < MAX_OUTPUT; i++)
+	{
+	    if (pinNotPresent(ignored_bool_outputs, ARRAY_SIZE(ignored_bool_outputs), i))
+	    	pinMode(outBufferPinMask[i], OUTPUT);
+	}
+	pwmSetRange(1024);
+	pwmSetClock(1);
+	//set PWM pins as output
+	for (int i = 0; i < MAX_ANALOG_OUT; i++)
+	{
+		if (pinNotPresent(ignored_int_outputs, ARRAY_SIZE(ignored_int_outputs), analogOutBufferPinMask[i])) {
+	    	pinMode(analogOutBufferPinMask[i], PWM_OUTPUT);
+		}
+	}
+
+}
+
+//-----------------------------------------------------------------------------
+// This function is called by the main OpenPLC routine when it is finalizing.
+// Resource clearing procedures should be here.
+//-----------------------------------------------------------------------------
+void finalizeHardware()
+{
+}
+
+//-----------------------------------------------------------------------------
+// This function is called by the OpenPLC in a loop. Here the internal buffers
+// must be updated to reflect the actual Input state. The mutex bufferLock
+// must be used to protect access to the buffers on a threaded environment.
+//-----------------------------------------------------------------------------
+void updateBuffersIn()
+{
+	pthread_mutex_lock(&bufferLock); //lock mutex
+
+	//INPUT
+	for (int i = 0; i < MAX_INPUT; i++)
+	{
+	    if (pinNotPresent(ignored_bool_inputs, ARRAY_SIZE(ignored_bool_inputs), i))
+    		if (bool_input[i/8][i%8] != NULL) *bool_input[i/8][i%8] = digitalRead(inBufferPinMask[i]);
+	}
+
+	pthread_mutex_unlock(&bufferLock); //unlock mutex
+}
+
+//-----------------------------------------------------------------------------
+// This function is called by the OpenPLC in a loop. Here the internal buffers
+// must be updated to reflect the actual Output state. The mutex bufferLock
+// must be used to protect access to the buffers on a threaded environment.
+//-----------------------------------------------------------------------------
+void updateBuffersOut()
+{
+	pthread_mutex_lock(&bufferLock); //lock mutex
+
+	//OUTPUT
+	for (int i = 0; i < MAX_OUTPUT; i++)
+	{
+	    if (pinNotPresent(ignored_bool_outputs, ARRAY_SIZE(ignored_bool_outputs), i))
+    		if (bool_output[i/8][i%8] != NULL) digitalWrite(outBufferPinMask[i], *bool_output[i/8][i%8]);
+	}
+	//ANALOG OUT (PWM)
+	for (int i = 0; i < MAX_ANALOG_OUT; i++)
+	{
+	    if (pinNotPresent(ignored_int_outputs, ARRAY_SIZE(ignored_int_outputs), i))
+    		if (int_output[i] != NULL) pwmWrite(analogOutBufferPinMask[i], (*int_output[i] / 64));
+	}
+
+	pthread_mutex_unlock(&bufferLock); //unlock mutex
+}
+

--- a/webserver/core/hardware_layers/opi_zero2.cpp
+++ b/webserver/core/hardware_layers/opi_zero2.cpp
@@ -40,7 +40,7 @@
 
 #define MAX_INPUT 		4
 #define MAX_OUTPUT 		5
-#define MAX_ANALOG_OUT	2
+// #define MAX_ANALOG_OUT	2
 
 /********************I/O PINS CONFIGURATION*********************
  * A good source for Orange Pi I/O pins information is:
@@ -58,7 +58,7 @@ int inBufferPinMask[MAX_INPUT] = { 2, 5, 7, 8 };
 int outBufferPinMask[MAX_OUTPUT] = { 6, 9, 10, 13, 16 };
 
 //analogOutBufferPinMask: pin mask for the analog PWM
-//output of the RaspberryPi
+//output of the Orange Pi
 int analogOutBufferPinMask[MAX_ANALOG_OUT] = { 3, 4 };
 
 //-----------------------------------------------------------------------------
@@ -85,15 +85,15 @@ void initializeHardware()
 	    if (pinNotPresent(ignored_bool_outputs, ARRAY_SIZE(ignored_bool_outputs), i))
 	    	pinMode(outBufferPinMask[i], OUTPUT);
 	}
-	pwmSetRange(1024);
-	pwmSetClock(1);
-	//set PWM pins as output
-	for (int i = 0; i < MAX_ANALOG_OUT; i++)
-	{
-		if (pinNotPresent(ignored_int_outputs, ARRAY_SIZE(ignored_int_outputs), analogOutBufferPinMask[i])) {
-	    	pinMode(analogOutBufferPinMask[i], PWM_OUTPUT);
-		}
-	}
+	// pwmSetRange(1024);
+	// pwmSetClock(1);
+	// //set PWM pins as output
+	// for (int i = 0; i < MAX_ANALOG_OUT; i++)
+	// {
+	// 	if (pinNotPresent(ignored_int_outputs, ARRAY_SIZE(ignored_int_outputs), analogOutBufferPinMask[i])) {
+	//     	pinMode(analogOutBufferPinMask[i], PWM_OUTPUT);
+	// 	}
+	// }
 
 }
 
@@ -140,11 +140,11 @@ void updateBuffersOut()
     		if (bool_output[i/8][i%8] != NULL) digitalWrite(outBufferPinMask[i], *bool_output[i/8][i%8]);
 	}
 	//ANALOG OUT (PWM)
-	for (int i = 0; i < MAX_ANALOG_OUT; i++)
-	{
-	    if (pinNotPresent(ignored_int_outputs, ARRAY_SIZE(ignored_int_outputs), i))
-    		if (int_output[i] != NULL) pwmWrite(analogOutBufferPinMask[i], (*int_output[i] / 64));
-	}
+	// for (int i = 0; i < MAX_ANALOG_OUT; i++)
+	// {
+	//     if (pinNotPresent(ignored_int_outputs, ARRAY_SIZE(ignored_int_outputs), i))
+    // 		if (int_output[i] != NULL) pwmWrite(analogOutBufferPinMask[i], (*int_output[i] / 64));
+	// }
 
 	pthread_mutex_unlock(&bufferLock); //unlock mutex
 }

--- a/webserver/scripts/change_hardware_layer.sh
+++ b/webserver/scripts/change_hardware_layer.sh
@@ -73,6 +73,13 @@ elif [ "$1" == "rpi_old" ]; then
     echo rpi > ../scripts/openplc_platform
     echo rpi_old > ../scripts/openplc_driver
 
+elif [[ $1 == opi* ]]; then
+    echo "Activating Orange Pi driver"
+    cp ./hardware_layers/$1.cpp ./hardware_layer.cpp
+    echo "Setting Platform"
+    echo opi > ../scripts/openplc_platform
+    echo "$1" > ../scripts/openplc_driver
+
 elif [ "$1" == "simulink" ]; then
     echo "Activating Simulink driver"
     cp ./hardware_layers/simulink.cpp ./hardware_layer.cpp

--- a/webserver/scripts/compile_program.sh
+++ b/webserver/scripts/compile_program.sh
@@ -150,6 +150,35 @@ elif [ "$OPENPLC_PLATFORM" = "rpi" ]; then
     fi
     echo "Compilation finished successfully!"
     exit 0
+
+elif [ "$OPENPLC_PLATFORM" = "opi" ]; then
+    WIRINGOP_INC="-I/usr/local/include -L/usr/local/lib -lwiringPi -lwiringPiDev"
+    echo "Compiling for Orange Pi"
+    echo "Generating object files..."
+    g++ -std=gnu++11 -I ./lib -c Config0.c -lasiodnp3 -lasiopal -lopendnp3 -lopenpal -w $WIRINGOP_INC
+    if [ $? -ne 0 ]; then
+        echo "Error compiling C files"
+        echo "Compilation finished with errors!"
+        exit 1
+    fi
+    g++ -std=gnu++11 -I ./lib -c Res0.c -lasiodnp3 -lasiopal -lopendnp3 -lopenpal -w $WIRINGOP_INC
+    if [ $? -ne 0 ]; then
+        echo "Error compiling C files"
+        echo "Compilation finished with errors!"
+        exit 1
+    fi
+    echo "Generating glueVars..."
+    ./glue_generator
+    echo "Compiling main program..."
+    g++ -std=gnu++11 *.cpp *.o -o openplc -I ./lib -lrt -lpthread -fpermissive `pkg-config --cflags --libs libmodbus` -lasiodnp3 -lasiopal -lopendnp3 -lopenpal -w $WIRINGOP_INC
+    if [ $? -ne 0 ]; then
+        echo "Error compiling C files"
+        echo "Compilation finished with errors!"
+        exit 1
+    fi
+    echo "Compilation finished successfully!"
+    exit 0
+
 else
     echo "Error: Undefined platform! OpenPLC can only compile for Windows, Linux and Raspberry Pi environments"
     echo "Compilation finished with errors!"

--- a/webserver/webserver.py
+++ b/webserver/webserver.py
@@ -1713,6 +1713,8 @@ def hardware():
             else: return_str += "<option value='rpi'>Raspberry Pi</option>"
             if (current_driver == "rpi_old"): return_str += "<option selected='selected' value='rpi_old'>Raspberry Pi - Old Model (2011 model B)</option>"
             else: return_str += "<option value='rpi_old'>Raspberry Pi - Old Model (2011 model B)</option>"
+            if (current_driver == "opi_zero2"): return_str += "<option selected='selected' value='opi_zero2'>Orange Pi Zero2/Zero2 LTS/Zero2 B</option>"
+            else: return_str += "<option value='opi_zero2'>Orange Pi Zero2/Zero2 LTS/Zero2 B</option>"
             if (current_driver == "simulink"): return_str += "<option selected='selected' value='simulink'>Simulink</option>"
             else: return_str += "<option value='simulink'>Simulink</option>"
             if (current_driver == "simulink_linux"): return_str += "<option selected='selected' value='simulink_linux'>Simulink with DNP3 (Linux only)</option>"


### PR DESCRIPTION
Adds the Orange Pi as a platform and contains an example hardware layer for the Orange Pi Zero2/Zero2 LTS/Zero2 B