### PR TITLE
Docker fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,27 +4,27 @@ COPY . /workdir
 
 WORKDIR /workdir
 
-RUN mkdir /persistent
+RUN mkdir /docker_persistent
 
-VOLUME /persistent
+VOLUME /docker_persistent
 
 RUN ./install.sh docker \
-    && touch /persistent/mbconfig.cfg \
-    && touch /persistent/persistent.file \
-    && mkdir /persistent/st_files \
-    && cp /workdir/webserver/openplc.db /persistent/openplc.db \
+    && touch /docker_persistent/mbconfig.cfg \
+    && touch /docker_persistent/persistent.file \
+    && mkdir /docker_persistent/st_files \
+    && cp /workdir/webserver/openplc.db /docker_persistent/openplc.db \
     && mv /workdir/webserver/openplc.db /workdir/webserver/openplc_default.db \
-    && cp /workdir/webserver/dnp3.cfg /persistent/dnp3.cfg \
+    && cp /workdir/webserver/dnp3.cfg /docker_persistent/dnp3.cfg \
     && mv /workdir/webserver/dnp3.cfg /workdir/webserver/dnp3_default.cfg \
-    && cp -r /workdir/webserver/st_files/ /persistent/st_files/ \
+    && cp -r /workdir/webserver/st_files/ /docker_persistent/st_files/ \
     && mv /workdir/webserver/st_files /workdir/webserver/st_files_default \
-    && cp /workdir/webserver/active_program /persistent/active_program \
+    && cp /workdir/webserver/active_program /docker_persistent/active_program \
     && mv /workdir/webserver/active_program /workdir/webserver/active_program_default \
-    && ln -s /persistent/mbconfig.cfg /workdir/webserver/mbconfig.cfg \
-    && ln -s /persistent/persistent.file /workdir/webserver/persistent.file \
-    && ln -s /persistent/openplc.db /workdir/webserver/openplc.db \
-    && ln -s /persistent/dnp3.cfg /workdir/webserver/dnp3.cfg \
-    && ln -s /persistent/st_files /workdir/webserver/st_files \
-    && ln -s /persistent/active_program /workdir/webserver/active_program
+    && ln -s /docker_persistent/mbconfig.cfg /workdir/webserver/mbconfig.cfg \
+    && ln -s /docker_persistent/persistent.file /workdir/webserver/persistent.file \
+    && ln -s /docker_persistent/openplc.db /workdir/webserver/openplc.db \
+    && ln -s /docker_persistent/dnp3.cfg /workdir/webserver/dnp3.cfg \
+    && ln -s /docker_persistent/st_files /workdir/webserver/st_files \
+    && ln -s /docker_persistent/active_program /workdir/webserver/active_program
 
 ENTRYPOINT ["./start_openplc.sh"]

--- a/background_installer.sh
+++ b/background_installer.sh
@@ -304,6 +304,7 @@ if [ -d "/docker_persistent" ]; then
     mkdir -p /docker_persistent/st_files
     cp -n /workdir/webserver/dnp3_default.cfg /docker_persistent/dnp3.cfg
     cp -n /workdir/webserver/openplc_default.db /docker_persistent/openplc.db
+    cp -n /workdir/webserver/active_program_default /docker_persistent/active_program
     cp -n /workdir/webserver/st_files_default/* /docker_persistent/st_files/
     cp -n /dev/null /docker_persistent/persistent.file
     cp -n /dev/null /docker_persistent/mbconfig.cfg


### PR DESCRIPTION
Persistent folder in start_openplc.sh was changed in commit https://github.com/thiagoralves/OpenPLC_v3/commit/a8928f802fe8b39c280ba82ca8805c3adcae2095, but was not changed in Dockerfile.

When docker is running with empty folder for a volume, required files are not created in the volume location.

Also "active_program" is missing in persistent folder
Fixes:
> Traceback (most recent call last):
>   File "/workdir/webserver/webserver.py", line 2423, in <module>
>     file = open("active_program", "r")
> FileNotFoundError: [Errno 2] No such file or directory: 'active_program'
