### PR TITLE
Fix incorrect assignment operator (= instead of +=)

### DIFF
--- a/webserver/core/enip.cpp
+++ b/webserver/core/enip.cpp
@@ -586,7 +586,7 @@ int processEnipMessage(unsigned char *buffer, int buffer_size)
     }*/
     else
     {
-        p = sprintf(p, "Unknown EtherNet/IP request: ");
+        p += sprintf(p, "Unknown EtherNet/IP request: ");
         int msg_size;
         if (((buffer_size * 3) + 40) < log_msg_max_size) // Each byte on buffer takes 3 bytes to be printed using "%02x ". Add 40 extra bytes for "preamble"
         {


### PR DESCRIPTION
Hi,
I noticed a small issue in enip.cpp where = was used instead of +=. This could cause unexpected behavior by overwriting the value instead of incrementing it. Thanks :)