### PR TITLE
fix oplc_snap7 MyWord initialization

### DIFF
--- a/utils/snap7_src/wrapper/oplc_snap7.cpp
+++ b/utils/snap7_src/wrapper/oplc_snap7.cpp
@@ -874,7 +874,7 @@ int getBytesFromWordArray(pWordArray wordArray, int Start, int Size, pbyte pUsrD
 {
     int WordStart = Start / 2;
     int WordAmount = Size / 2;
-    uint16_t MyWord = NULL;
+    uint16_t MyWord;
     int idx = 0;
 
     if (WordStart + WordAmount >= BUFFER_SIZE)


### PR DESCRIPTION
cannot convert 'std::nullptr_t' to 'uint16_t' {aka 'short unsigned int'} in initialization