### PR TITLE
Update to latest Trixie.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-20240722
+FROM debian:trixie-20251020
 
 COPY . /workdir
 


### PR DESCRIPTION
This is in relation to #301 

Updating to lastest stable Debian version. This changes the version of Python installed by apt, such that type hinting is supported.

Web server starts fine now, but will likely need more testing.

This update is probably necessary soon anyway as bookworm has seen end of LTS in August this year.