### PR TITLE
Resolve compilation failure on Windows MSYS2

### DIFF
--- a/background_installer.sh
+++ b/background_installer.sh
@@ -324,7 +324,9 @@ elif [ "$1" == "win_msys2" ]; then
     install_glue_generator
     disable_opendnp3
     install_libmodbus
-    cp /usr/include/modbus/*.h /usr/include/
+    # [FIX] Copy libmodbus headers to the expected include path for MSYS2 builds.
+    mkdir -p /usr/include/modbus
+    cp /mingw64/include/modbus/*.h /usr/include/modbus/
     finalize_install win
 
 elif [ "$1" == "linux" ]; then


### PR DESCRIPTION
The **Windows installation script fails** during the main program compilation
with a "fatal error: modbus.h: No such file or directory".

This occurs **because libmodbus installs its headers to the MinGW-specific
path** (/mingw64/include/modbus), **but the compiler expects them in a
standard system path** (/usr/include/modbus).

This patch fixes the build by adding a step to create the target
directory and copy the necessary header files to the expected location
before the final compilation begins.