### PR TITLE
Improper casting in start_ethercat() command parsing.

### DIFF
--- a/webserver/core/interactive_server.cpp
+++ b/webserver/core/interactive_server.cpp
@@ -282,7 +282,7 @@ void processCommand(unsigned char *buffer, int client_fd)
     {
         processing_command = true;
         char *argument;
-        argument = (char)readCommandArgumentStr(buffer);
+        argument = readCommandArgumentStr(buffer);
         strcpy(ethercat_conf_file, argument);
         free(argument);
         sprintf(log_msg, "Issued start_ethercat() command to start with config: %s\n", ethercat_conf_file);


### PR DESCRIPTION
When sending start_ethercat(ethercat_conf_file), the command parser casts the char pointer to a char and causes a segmentation fault.