### PR TITLE
Fixed hostname editing functionality

### DIFF
--- a/webserver/webserver.py
+++ b/webserver/webserver.py
@@ -2509,7 +2509,7 @@ def settings():
             # Change hostname if needed
             current_hostname = socket.gethostname()
             if current_hostname != None and current_hostname != device_hostname:
-                subprocess.run(['hostnamectl', 'set-hostname', device_hostname])
+                open("/etc/hostname", 'w').write(device_hostname + '\n')
 
             database = "openplc.db"
             conn = create_connection(database)


### PR DESCRIPTION
The hostnamectl binary was non-existent in the docker container.

A quick easy fix was to directly write to the /etc/hostname file which is what hostnamectl binary did anyway.

Furthermore, we are writing the sanitized input as well as it was originally passed into sanitize_input in the code before my changes anyway.

Lastly, this will persist in between reboots which is intended behavior (and the hostnamectl binary did the same).