### PR TITLE
Fix Simulink driver bug

### DIFF
--- a/webserver/core/hardware_layers/simulink.cpp
+++ b/webserver/core/hardware_layers/simulink.cpp
@@ -38,10 +38,6 @@
 
 #include "ladder.h"
 
-#if !defined(ARRAY_SIZE)
-    #define ARRAY_SIZE(x) (sizeof((x)) / sizeof((x)[0]))
-#endif
-
 #define PORT        6668
 
 #define ANALOG_BUF_SIZE		8
@@ -131,19 +127,13 @@ void *exchangeData(void *arg)
             pthread_mutex_lock(&bufferLock); //lock mutex
             for (int i = 0; i < ANALOG_BUF_SIZE; i++)
             {
-                if (pinNotPresent(ignored_int_inputs, ARRAY_SIZE(ignored_int_inputs), i))
-                    if (int_input[i] != NULL) *int_input[i] = plc_data->analogIn[i];
-
-                if (pinNotPresent(ignored_int_outputs, ARRAY_SIZE(ignored_int_outputs), i))
-                    if (int_output[i] != NULL) plc_data->analogOut[i] = *int_output[i];
+                if (int_input[i] != NULL) *int_input[i] = plc_data->analogIn[i];
+                if (int_output[i] != NULL) plc_data->analogOut[i] = *int_output[i];
             }
             for (int i = 0; i < DIGITAL_BUF_SIZE; i++)
             {
-                if (pinNotPresent(ignored_bool_inputs, ARRAY_SIZE(ignored_bool_inputs), i))
-                    if (bool_input[i/8][i%8] != NULL) *bool_input[i/8][i%8] = plc_data->digitalIn[i];
-                
-                if (pinNotPresent(ignored_bool_outputs, ARRAY_SIZE(ignored_bool_outputs), i))
-                    if (bool_output[i/8][i%8] != NULL) plc_data->digitalOut[i] = *bool_output[i/8][i%8];
+                if (bool_input[i/8][i%8] != NULL) *bool_input[i/8][i%8] = plc_data->digitalIn[i];
+                if (bool_output[i/8][i%8] != NULL) plc_data->digitalOut[i] = *bool_output[i/8][i%8];
             }
             pthread_mutex_unlock(&bufferLock); //unlock mutex
 


### PR DESCRIPTION
This pull request simplifies the `exchangeData` function in `simulink.cpp` by removing checks for ignored pins and eliminates a redundant macro definition. The changes streamline the code, making it easier to read and maintain.

Code cleanup and simplification:

* Removed the definition of the `ARRAY_SIZE` macro, as it is no longer needed. (`webserver/core/hardware_layers/simulink.cpp`)
* Simplified the `exchangeData` function by removing conditional checks using `pinNotPresent` and `ARRAY_SIZE`, so pin assignments are now unconditional if the pointer is not `NULL`. (`webserver/core/hardware_layers/simulink.cpp`)